### PR TITLE
전역 예외 처리기 등록

### DIFF
--- a/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
@@ -1,0 +1,16 @@
+package com.emr.slgi.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests.requestMatchers("/**").permitAll())
+            .csrf((csrf) -> csrf.ignoringRequestMatchers("/**"))
+            .build();
+    }
+}

--- a/server/src/main/java/com/emr/slgi/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/emr/slgi/exception/GlobalExceptionHandler.java
@@ -2,7 +2,9 @@ package com.emr.slgi.exception;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,7 +15,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException exception) {
         Map<String, Object> map = new HashMap<>();
-        map.put("message", exception.getReason());
+        map.put(
+            "message",
+            Optional.ofNullable(exception.getReason()).orElse(((HttpStatus)exception.getStatusCode()).getReasonPhrase())
+        );
         return ResponseEntity.status(exception.getStatusCode()).body(map);
     }
 }

--- a/server/src/main/java/com/emr/slgi/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/emr/slgi/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.emr.slgi.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatusException(ResponseStatusException exception) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", exception.getReason());
+        return ResponseEntity.status(exception.getStatusCode()).body(map);
+    }
+}


### PR DESCRIPTION
# 작업 내용
- ResponseStatusException에 대한 전역 예외 처리기 등록
- 응답 구조
```
{ message: "메세지" }
```
- Reason을 설정 시에는 Reason, 설정 안 할 시에는 상태 코드의 기본적인 메세지를 넣어서 보낸다.