### PR TITLE
@Valid 실패 시에 대한 전역 예외 처리기

### DIFF
--- a/server/src/main/java/com/emr/slgi/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/emr/slgi/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.server.ResponseStatusException;
@@ -26,4 +27,11 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(exception.getStatusCode()).body(map);
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidException(MethodArgumentNotValidException e) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("message", "Invalid Request");
+        map.put("errors", e.getFieldErrors().stream().map((err) -> err.getField() + ": " + err.getDefaultMessage()).toList());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(map);
+    }
 }


### PR DESCRIPTION
# 작업 내용
- `@Valid`는 실패 시에 `BindingResult`로 잡지 않으면 `MethodArgumentNotValidException`를 던진다.
- 해당 예외 안에 있는 오류들을 `errors`에 넣어서 응답하도록 한다. 응답은 다음 형식으로 보낸다.
  ```
  {
    message: "Invalid Request",
    errors: [ "에러 내용" ]
  }
  ```
