### PR TITLE
스웨거 설정

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 
 tasks.named('test') {

--- a/server/src/main/java/com/emr/slgi/config/SwaggerConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/SwaggerConfig.java
@@ -1,0 +1,14 @@
+package com.emr.slgi.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+
+@OpenAPIDefinition(
+  info = @Info(
+    title = "MSA medical",
+    version = "0.0.1",
+    description = "환자 예약 진료 관리 시스템 API"
+  )
+)
+public class SwaggerConfig {
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -19,3 +19,7 @@ mybatis:
   configuration:
     map-underscore-to-camel-case: true
 #  type-aliases-package: com.emr.slgi.member
+
+springdoc:
+  swagger-ui:
+    path: /api-docs


### PR DESCRIPTION
# 작업 내용
- swagger 의존성 추가
- swagger 문서 경로 설정
  - /api-docs로 문서 이동 가능.
  - springdoc.swagger-ui.path 설정을 사용해서 swagger 페이지에 대한 경로 설정
- @OpenAPIDefinition를 사용한 문서 설정
