### PR TITLE
ISO8601 형식으로 넘기는 타임존(Z) 정보를 가진 UTC 데이터를 전역으로 직렬화 / 역직렬화 수행.

### DIFF
--- a/server/src/main/java/com/emr/slgi/config/DateTimeConverterConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/DateTimeConverterConfig.java
@@ -1,0 +1,14 @@
+package com.emr.slgi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class DateTimeConverterConfig implements WebMvcConfigurer { // PathVariable, 쿼리스트링 직렬화
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToKstLocalDateTimeConverter());
+    }
+}
+

--- a/server/src/main/java/com/emr/slgi/config/JacksonDateTimeConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/JacksonDateTimeConfig.java
@@ -1,0 +1,31 @@
+package com.emr.slgi.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonDateTimeConfig {
+    // Body의 JSON 데이터 내 시간을 직렬화 역직렬화
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer kstDeserializer() { // UTC의 Zone 데이터를 가지고 KST로 변환(직렬화)
+        return builder -> builder.deserializers(new StdDeserializer<LocalDateTime>(LocalDateTime.class) {
+            @Override
+            public LocalDateTime deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+                OffsetDateTime odt = OffsetDateTime.parse(p.getText());
+                return odt.atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+            }
+        });
+    }
+
+}
+

--- a/server/src/main/java/com/emr/slgi/config/JacksonTimeZoneConverter.java
+++ b/server/src/main/java/com/emr/slgi/config/JacksonTimeZoneConverter.java
@@ -1,0 +1,15 @@
+package com.emr.slgi.config;
+
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+
+import java.util.TimeZone;
+
+public class JacksonTimeZoneConverter {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer timezoneCustomizer() { // KST를 Zone 데이터 가진 UTC로 변환(역직렬화)
+        return builder -> builder.timeZone(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+
+}

--- a/server/src/main/java/com/emr/slgi/config/StringToKstLocalDateTimeConverter.java
+++ b/server/src/main/java/com/emr/slgi/config/StringToKstLocalDateTimeConverter.java
@@ -1,0 +1,17 @@
+package com.emr.slgi.config;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.core.convert.converter.GenericConverter;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+public class StringToKstLocalDateTimeConverter implements Converter<String, LocalDateTime> {
+    @Override
+    public LocalDateTime convert(String source) {
+        OffsetDateTime odt = OffsetDateTime.parse(source);
+        return odt.atZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+    }
+}
+


### PR DESCRIPTION
# 작업내용
## ISO8601 형식으로 넘기는 타임존(Z) 정보를 가진 UTC 데이터를<br/> 전역으로 직렬화 / 역직렬화 수행.
### PathVariable 또는 쿼리 스트링으로 넘어오는 UTC 데이터 직렬화 및 역직렬화
- DateTimeConverterConfig.java 로 전역 설정
- StringToKstLocalDateTimeConverter는 실제 직렬화와 역직렬화 수행
### Body 내 JSON 형식으로 넘어오는 UTC 데이터 직렬화 및 역직렬화
-  JacksonDateTimeConfig는 Body의 JSON 내 직렬화와 역직렬화 전역 설정
-  JacksonTimeZoneConverter는 Body의 JSON 내 직렬화와 역직렬화 수행
### 주의사항
- 서버에서 받을 경우, LocalDateTime 타입으로 받아서 사용. <br/>
(DTO 사용 가능. DTO 내부에 LocalDateTime 타입 사용)
- 클라이언트에서 보낼 경우, toISOString 함수를 사용하거나 ISO8601 형식으로 타임존 정보 담아서 문자열 형식으로 보내기.
