### PR TITLE
유저 프로필 가져오기

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,4 +3,8 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue';
+import { getMe } from '@/util/getMe';
+
+onMounted(getMe);
 </script>

--- a/frontend/src/components/auth/LoginForm.vue
+++ b/frontend/src/components/auth/LoginForm.vue
@@ -16,6 +16,7 @@
 import { setAccessToken } from '@/auth/accessToken';
 import { customFetch } from '@/util/customFetch';
 import { ENDPOINTS } from '@/util/endpoints';
+import { getMe } from '@/util/getMe';
 import { reactive } from 'vue';
 import { useRouter } from 'vue-router';
 
@@ -31,6 +32,7 @@ async function login() {
     data: user
   });
   setAccessToken(response.data.accessToken);
+  await getMe();
   router.push({ name: 'home' });
 }
 </script>

--- a/frontend/src/stores/userStore.js
+++ b/frontend/src/stores/userStore.js
@@ -1,0 +1,15 @@
+import { defineStore } from "pinia";
+
+export const useUserStore = defineStore('user', {
+  state: () => ({
+    user: null
+  }),
+  actions: {
+    setUser(user) {
+      this.user = user;
+    },
+    clearUser() {
+      this.user = null;
+    }
+  }
+});

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -24,6 +24,10 @@ export const ENDPOINTS = {
             method: 'post',
             url: '/member'
         },
+        me: {
+            method: 'get',
+            url: '/member/me'
+        }
     },
     patient: {
         register: {

--- a/frontend/src/util/getMe.js
+++ b/frontend/src/util/getMe.js
@@ -1,0 +1,9 @@
+import { useUserStore } from "@/stores/userStore";
+import { customFetch } from "./customFetch";
+import { ENDPOINTS } from "./endpoints";
+
+export async function getMe() {
+  const userStore = useUserStore();
+  const response = await customFetch(ENDPOINTS.member.me);
+  userStore.setUser(response.data);
+}

--- a/server/src/main/java/com/emr/slgi/member/controller/MemberController.java
+++ b/server/src/main/java/com/emr/slgi/member/controller/MemberController.java
@@ -1,0 +1,25 @@
+package com.emr.slgi.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.emr.slgi.member.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/member")
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+
+  @GetMapping("/me")
+  public ResponseEntity<?> me(@AuthenticationPrincipal String uuid) {
+    return ResponseEntity.ok(memberService.getByUuid(uuid));
+  }
+
+}


### PR DESCRIPTION
# 작업 내용
## userStore 작성
- 기존의 couter.js 내에 있던 유저 정보 store 수정
- couter.js의 이름을 변경하는 대신에 새로 작성(충돌 고려)
- `useUserStore()`를 사용해서 user 정보를 가져올 수 있음
  ```
  import { useUserStore } from "@/stores/userStore";
  
  const userStore = useUserStore();
  const user = userStore.user;
  ```
## 루트 컴포넌트 마운트 시, 로그인 시에 유저 정보 가져오기
- 현재는 Member 테이블의 모든 컬럼을 가져오지만 추후 논의 후에 최소화시킬 예정
