### PR TITLE
의료진용 환자 대기 리스트 기본 구현

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router'
 import ChatRooms from '@/components/chat/ChatRooms.vue'
 import ChatRoom from '@/components/chat/ChatRoom.vue'
 import { patientRoutes } from './patientRoutes';
+import {receptionRoutes} from "@/router/receptionRoutes.js";
 
 
 const HomeView = () => import('@/views/HomeView.vue');
@@ -10,6 +11,7 @@ const OtherView = () => import('@/views/other/OtherView.vue');
 const AcceptPatientByStaff = () => import('@/views/reception/AcceptPatientByStaff.vue')
 const RegReservationByPatient = () => import('@/views/reservation/RegReservationByPatient.vue')
 const LoginView = () => import('@/views/auth/LoginView.vue');
+const Reception = () => import('@/views/reception/Reception.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -54,7 +56,14 @@ const router = createRouter({
     {
       path: '/acceptPatientByStaff',
       name: 'acceptPatientByStaff',
-      component: AcceptPatientByStaff
+
+    },
+    {
+      path: '/reception',
+      component: Reception,
+      children: [
+          ...receptionRoutes
+      ]
     }
   ],
 })

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,10 +8,9 @@ import {receptionRoutes} from "@/router/receptionRoutes.js";
 const HomeView = () => import('@/views/HomeView.vue');
 const MainView = () => import('@/views/home/MainView.vue');
 const OtherView = () => import('@/views/other/OtherView.vue');
-const AcceptPatientByStaff = () => import('@/views/reception/AcceptPatientByStaff.vue')
 const RegReservationByPatient = () => import('@/views/reservation/RegReservationByPatient.vue')
 const LoginView = () => import('@/views/auth/LoginView.vue');
-const Reception = () => import('@/views/reception/Reception.vue')
+const Reception = () => import('@/views/reception/WaitingList.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -60,6 +59,7 @@ const router = createRouter({
     },
     {
       path: '/reception',
+      name: 'reception',
       component: Reception,
       children: [
           ...receptionRoutes

--- a/frontend/src/router/receptionRoutes.js
+++ b/frontend/src/router/receptionRoutes.js
@@ -1,12 +1,12 @@
-import AcceptPatientByStaff from "@/views/reception/AcceptPatientByStaff.vue";
-import WaitingListPatientList from '@/views/reception/WaitingListPatientList.vue'
-import WaitingListDoctorName from "@/views/reception/WaitingListDoctorName.vue";
-import WaitingList from "@/views/reception/WaitingList.vue";
+const AcceptPatientByStaff = () => import("@/views/reception/AcceptPatientByStaff.vue");
+const WaitingListPatientList = () => import('@/views/reception/WaitingListPatientList.vue');
+const WaitingListDoctorName = () => import("@/views/reception/WaitingListDoctorName.vue");
+const WaitingListPerDoctor = () => import('@/views/reception/WaitingListPerDoctor.vue');
 
 export const receptionRoutes = [
     {
-        path: '/',
-        name: 'reception',
+        path: '/acceptPatientByStaff',
+        name: 'acceptPatientByStaff',
         component: AcceptPatientByStaff
     },
     {
@@ -20,8 +20,8 @@ export const receptionRoutes = [
         component: WaitingListDoctorName
     },
     {
-        path: '/waitingList',
-        name: 'waitingList',
-        component: WaitingList
-    }
+        path: '/waitingListPerDoctor',
+        name: 'waitingListPerDoctor',
+        component: WaitingListPerDoctor
+    },
 ]

--- a/frontend/src/router/receptionRoutes.js
+++ b/frontend/src/router/receptionRoutes.js
@@ -1,0 +1,27 @@
+import AcceptPatientByStaff from "@/views/reception/AcceptPatientByStaff.vue";
+import WaitingListPatientList from '@/views/reception/WaitingListPatientList.vue'
+import WaitingListDoctorName from "@/views/reception/WaitingListDoctorName.vue";
+import WaitingList from "@/views/reception/WaitingList.vue";
+
+export const receptionRoutes = [
+    {
+        path: '/',
+        name: 'reception',
+        component: AcceptPatientByStaff
+    },
+    {
+        path: '/waitingListPatientList',
+        name: 'waitingListPatientList',
+        component: WaitingListPatientList
+    },
+    {
+        path: '/waitingListDoctorName',
+        name: 'waitingListDoctorName',
+        component: WaitingListDoctorName
+    },
+    {
+        path: '/waitingList',
+        name: 'waitingList',
+        component: WaitingList
+    }
+]

--- a/frontend/src/router/receptionRoutes.js
+++ b/frontend/src/router/receptionRoutes.js
@@ -9,19 +9,4 @@ export const receptionRoutes = [
         name: 'acceptPatientByStaff',
         component: AcceptPatientByStaff
     },
-    {
-        path: '/waitingListPatientList',
-        name: 'waitingListPatientList',
-        component: WaitingListPatientList
-    },
-    {
-        path: '/waitingListDoctorName',
-        name: 'waitingListDoctorName',
-        component: WaitingListDoctorName
-    },
-    {
-        path: '/waitingListPerDoctor',
-        name: 'waitingListPerDoctor',
-        component: WaitingListPerDoctor
-    },
 ]

--- a/frontend/src/stores/waitingListStore.js
+++ b/frontend/src/stores/waitingListStore.js
@@ -1,0 +1,67 @@
+import {defineStore} from "pinia";
+import {ref} from "vue";
+import {reception} from "@/util/reception.js";
+import {errorMessage} from "@/util/errorMessage.js";
+import {common} from "@/util/common.js";
+
+export const useWaitingListStore = defineStore('waitingList', () => {
+
+    const doctorList = ref();
+    // const waitingList = ref();
+    // const doctorName = reactive({
+    //     name: null
+    // });
+
+    const waitingListByNurse = async () => {
+
+        doctorList.value = await reception.getDoctorList();
+
+        console.log(doctorList.value);
+
+        if(doctorList.value == null) {
+            common.alertError(errorMessage.common.retry);
+        }
+
+        return await Promise.all(
+            doctorList.value.map(async (doctor) => {
+
+                const list = await reception.getWaitingList(doctor.uuid);
+
+                return {
+                    doctor,
+                    patientList: list
+                }
+
+            })
+        );
+
+    }
+
+    const waitingListByDoctor = async () => {
+
+        doctorList.value = [{
+            name: await reception.getDoctorName()
+        }]
+
+        return await Promise.all(
+            doctorList.value.map(async (doctor) => {
+
+                const list = await reception.getWaitingList('550e8400-e29b-41d4-a716-446655440000'); // 더미 데이터
+                // await reception.getWaitingList(localStorage.getItem('uuid'));
+
+                return {
+                    doctor,
+                    patientList: list
+                }
+
+            })
+        );
+
+    }
+
+    return {
+        waitingListByNurse,
+        waitingListByDoctor
+    };
+
+})

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -54,8 +54,8 @@ export const ENDPOINTS = {
         },
         getDoctorName : {
             method: 'get',
-            url: '/reception/getDoctorName'
-        }
+            url: `/reception/getDoctorName/${localStorage.getItem('uuid')}/${localStorage.getItem('role')}`
+        },
     },
     chat: {
         loadMemberList: (uuid) => ({

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -51,6 +51,10 @@ export const ENDPOINTS = {
         acceptPatientByStaff: {
             method: 'post',
             url: '/reception'
+        },
+        getDoctorName : {
+            method: 'get',
+            url: '/reception/getDoctorName'
         }
     },
     chat: {

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -56,14 +56,11 @@ export const ENDPOINTS = {
             method: 'post',
             url: '/reception'
         },
-        getDoctorName : {
+        getWaitingList: {
             method: 'get',
-            url: `/reception/getDoctorName/${localStorage.getItem('uuid')}/${localStorage.getItem('role')}`
+            // url: `/reception/getWaitingList/${localStorage.getItem('uuid')}`
+            url: '/reception/getWaitingList/550e8400-e29b-41d4-a716-446655440000' // 테스트용 데이터(localStorage에 데이터X)
         },
-        getWaitingList: (doctorUuid) => ({
-            method: 'get',
-            url: `/reception/getWaitingList/${doctorUuid}`
-        }),
     },
     chat: {
         loadMemberList: (uuid) => ({

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -39,7 +39,11 @@ export const ENDPOINTS = {
         list: {
             method: 'get',
             url: '/doctor/list'
-        }
+        },
+        name: (uuid) => ({
+            method: 'get',
+            url: `/doctor/${uuid}/name`
+        })
     },
     staff: {
         list: (uuid) => ({

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -56,6 +56,10 @@ export const ENDPOINTS = {
             method: 'get',
             url: `/reception/getDoctorName/${localStorage.getItem('uuid')}/${localStorage.getItem('role')}`
         },
+        getWaitingList: (doctorUuid) => ({
+            method: 'get',
+            url: `/reception/getWaitingList/${doctorUuid}`
+        }),
     },
     chat: {
         loadMemberList: (uuid) => ({

--- a/frontend/src/util/endpoints.js
+++ b/frontend/src/util/endpoints.js
@@ -54,13 +54,16 @@ export const ENDPOINTS = {
     reception: {
         acceptPatientByStaff: {
             method: 'post',
-            url: '/reception'
+            url: '/reception/acceptPatientByStaff'
         },
-        getWaitingList: {
+        getWaitingList: (uuid) => ({
             method: 'get',
-            // url: `/reception/getWaitingList/${localStorage.getItem('uuid')}`
-            url: '/reception/getWaitingList/550e8400-e29b-41d4-a716-446655440000' // 테스트용 데이터(localStorage에 데이터X)
-        },
+            url: `/reception/${uuid}`
+        }),
+        cancelReception: (uuid) => ({
+            method: 'put',
+            url: `/reception/${uuid}/cancel`
+        })
     },
     chat: {
         loadMemberList: (uuid) => ({

--- a/frontend/src/util/errorMessage.js
+++ b/frontend/src/util/errorMessage.js
@@ -4,7 +4,8 @@ export const errorMessage = {
         doctorChk: '의사를 선택해주세요.',
         dateChk: '날짜를 선택해주세요.',
         timeChk: '시간을 선택해주세요.',
-        symptomChk: '증상을 입력해주세요.'
+        symptomChk: '증상을 입력해주세요.',
+        retry: '다시 시도해주세요.'
     }
 
 }

--- a/frontend/src/util/reception.js
+++ b/frontend/src/util/reception.js
@@ -1,0 +1,10 @@
+import {ENDPOINTS} from "@/util/endpoints.js";
+import {customFetch} from "@/util/customFetch.js";
+
+export const reception = {
+
+    getDoctorName : () => {
+        customFetch(ENDPOINTS.reception.getDoctorName);
+    }
+
+}

--- a/frontend/src/util/reception.js
+++ b/frontend/src/util/reception.js
@@ -3,19 +3,14 @@ import {customFetch} from "@/util/customFetch.js";
 import {common} from "@/util/common.js";
 
 export const reception = {
-    getWaitingList: async (doctorUuid) => {
+    getWaitingList: async () => {
         console.log("b");
         try {
             console.log("c");
-            const response = await customFetch(ENDPOINTS.reception.getWaitingList(doctorUuid));
+            const response = await customFetch(ENDPOINTS.reception.getWaitingList);
 
             if(response?.status === 200) {
-                console.log("d");
-                alert("a");
-                const res = response.data?.waitingList;
-                console.log(res);
-                return res;
-                // return response.data?.waitingList;
+                return response.data?.waitingList;
             }
 
         } catch(err) {
@@ -25,13 +20,12 @@ export const reception = {
 
 
     },
-    
-    // 여기서 처리? 팀장님과 상의하기
     getDoctorName : async () => {
 
         try {
-
-            const response = await customFetch(ENDPOINTS.reception.getDoctorName);
+            
+            const response = await customFetch(ENDPOINTS.doctor.name('bbf7cf49-971c-47be-82cd-f613c633aa57')); // 테스트용 의사 번호 데이터
+                // await customFetch(ENDPOINTS.doctor.name(localStorage.getItem('uuid')));
 
             if(response?.status === 200) {
 

--- a/frontend/src/util/reception.js
+++ b/frontend/src/util/reception.js
@@ -1,10 +1,27 @@
 import {ENDPOINTS} from "@/util/endpoints.js";
 import {customFetch} from "@/util/customFetch.js";
+import {common} from "@/util/common.js";
 
 export const reception = {
 
-    getDoctorName : () => {
-        customFetch(ENDPOINTS.reception.getDoctorName);
+    getDoctorName : async () => {
+
+        try {
+
+            const response = await customFetch(ENDPOINTS.reception.getDoctorName);
+
+            if(response?.status === 200) {
+
+                return response.data?.name;
+
+            }
+
+        } catch(err) {
+
+            common.errMsg(err);
+
+        }
+
     }
 
 }

--- a/frontend/src/util/reception.js
+++ b/frontend/src/util/reception.js
@@ -1,13 +1,31 @@
 import {ENDPOINTS} from "@/util/endpoints.js";
 import {customFetch} from "@/util/customFetch.js";
 import {common} from "@/util/common.js";
+import {successMessage} from "@/util/successMessage.js";
 
 export const reception = {
-    getWaitingList: async () => {
+    getDoctorList: async () => {
+
+        try {
+
+            const response = await customFetch(ENDPOINTS.doctor.list);
+
+            if(response?.status === 200) {
+                return response.data?.list;
+            }
+
+        } catch(err) {
+
+            common.errMsg(err);
+
+        }
+
+    },
+    getWaitingList: async (uuid) => {
         console.log("b");
         try {
             console.log("c");
-            const response = await customFetch(ENDPOINTS.reception.getWaitingList);
+            const response = await customFetch(ENDPOINTS.reception.getWaitingList(uuid));
 
             if(response?.status === 200) {
                 return response.data?.waitingList;
@@ -39,6 +57,22 @@ export const reception = {
 
         }
 
-    }
+    },
+    cancelReception : async (uuid) => {
 
+        try {
+
+            const response = await customFetch(ENDPOINTS.reception.cancelReception(uuid));
+
+            if(response?.status === 200) {
+                common.alertError(successMessage.common.cancel);
+            }
+
+        } catch(err) {
+
+            common.errMsg(err);
+
+        }
+
+    }
 }

--- a/frontend/src/util/reception.js
+++ b/frontend/src/util/reception.js
@@ -3,7 +3,30 @@ import {customFetch} from "@/util/customFetch.js";
 import {common} from "@/util/common.js";
 
 export const reception = {
+    getWaitingList: async (doctorUuid) => {
+        console.log("b");
+        try {
+            console.log("c");
+            const response = await customFetch(ENDPOINTS.reception.getWaitingList(doctorUuid));
 
+            if(response?.status === 200) {
+                console.log("d");
+                alert("a");
+                const res = response.data?.waitingList;
+                console.log(res);
+                return res;
+                // return response.data?.waitingList;
+            }
+
+        } catch(err) {
+            console.log("f");
+            common.errMsg(err);
+        }
+
+
+    },
+    
+    // 여기서 처리? 팀장님과 상의하기
     getDoctorName : async () => {
 
         try {

--- a/frontend/src/util/successMessage.js
+++ b/frontend/src/util/successMessage.js
@@ -1,0 +1,11 @@
+export const successMessage = {
+
+    common : {
+        cancel : "취소됐습니다."
+    },
+    reception : {
+
+    }
+
+
+}

--- a/frontend/src/views/reception/Reception.vue
+++ b/frontend/src/views/reception/Reception.vue
@@ -1,0 +1,3 @@
+<template>
+  <router-view />
+</template>

--- a/frontend/src/views/reception/WaitingList.vue
+++ b/frontend/src/views/reception/WaitingList.vue
@@ -1,32 +1,44 @@
 <script setup>
-import {onMounted, reactive} from "vue";
-import {reception} from "@/util/reception.js";
+  import {useWaitingListStore} from "@/stores/waitingListStore.js";
+  import {onBeforeMount, ref} from "vue";
+  import WaitingListPerDoctor from "@/views/reception/WaitingListPerDoctor.vue";
+  import WaitingListDoctorName from "@/views/reception/WaitingListDoctorName.vue";
+  import WaitingListPatientList from "@/views/reception/WaitingListPatientList.vue";
 
-  const doctorName = reactive({
+  const waitingListStore = useWaitingListStore();
+  const waitingList = ref();
+  const role = 'R003'; // Role 더미 데이터
 
-    name: null
+  onBeforeMount(async () => {
 
-  });
+    // if(localStorage.getItem('role') === 'R002') {
+    if(role === 'R002') {
+      waitingList.value = await waitingListStore.waitingListByDoctor();
+    } else {
+      waitingList.value = await waitingListStore.waitingListByNurse();
+    }
 
-  const getDoctorName = () => {
+    console.log(waitingList.value);
 
-    doctorName.name = reception.getDoctorName;
+    // 웹소켓 연결부
+    // socket = new WebSocket('wss://your-server.com/ws')
+    //
+    // socket.onmessage = (event) => {
+    //   const message = JSON.parse(event.data)
+    //
+    //   if (message.type === 'refresh-doctor-data') {
+    //     doctorStore.fetchDoctors() // ✅ 핀리아 상태 자동 업데이트
+    //   }
+    // }
 
-  }
+  })
 
-  onMounted(
-      getDoctorName
-  )
 
 </script>
 
 <template>
-
-  <div class="container">
-    <div class="my-3">
-      <span v-cloak>{{doctorName.name}}</span>
-    </div>
-  </div>
-
-
+  <template v-for="list in waitingList">
+    <WaitingListDoctorName :value="list.doctor"/>
+    <WaitingListPatientList :value="list.patientList"/>
+  </template>
 </template>

--- a/frontend/src/views/reception/WaitingList.vue
+++ b/frontend/src/views/reception/WaitingList.vue
@@ -3,20 +3,16 @@ import {onMounted, reactive} from "vue";
 import {reception} from "@/util/reception.js";
 
   const doctorName = reactive({
-    name: String
+
+    name: null
+
   });
 
-  const roleCheck = () => {
-    localStorage.getItem('role');
-  }
-
   const getDoctorName = () => {
-    if(roleCheck() === 'R') {
 
-    }
-    doctorName.name = reception.getDoctorName();
+    doctorName.name = reception.getDoctorName;
+
   }
-
 
   onMounted(
       getDoctorName

--- a/frontend/src/views/reception/WaitingList.vue
+++ b/frontend/src/views/reception/WaitingList.vue
@@ -1,6 +1,6 @@
 <script setup>
   import {useWaitingListStore} from "@/stores/waitingListStore.js";
-  import {onBeforeMount, ref} from "vue";
+  import {onBeforeMount, onMounted, onUnmounted, ref} from "vue";
   import WaitingListPerDoctor from "@/views/reception/WaitingListPerDoctor.vue";
   import WaitingListDoctorName from "@/views/reception/WaitingListDoctorName.vue";
   import WaitingListPatientList from "@/views/reception/WaitingListPatientList.vue";
@@ -20,16 +20,15 @@
 
     console.log(waitingList.value);
 
+  })
+
+  onMounted(() => {
     // 웹소켓 연결부
-    // socket = new WebSocket('wss://your-server.com/ws')
-    //
-    // socket.onmessage = (event) => {
-    //   const message = JSON.parse(event.data)
-    //
-    //   if (message.type === 'refresh-doctor-data') {
-    //     doctorStore.fetchDoctors() // ✅ 핀리아 상태 자동 업데이트
-    //   }
-    // }
+
+  })
+
+  onUnmounted(() => {
+    // 웹 소켓 연결 해제부
 
   })
 

--- a/frontend/src/views/reception/WaitingList.vue
+++ b/frontend/src/views/reception/WaitingList.vue
@@ -1,0 +1,36 @@
+<script setup>
+import {onMounted, reactive} from "vue";
+import {reception} from "@/util/reception.js";
+
+  const doctorName = reactive({
+    name: String
+  });
+
+  const roleCheck = () => {
+    localStorage.getItem('role');
+  }
+
+  const getDoctorName = () => {
+    if(roleCheck() === 'R') {
+
+    }
+    doctorName.name = reception.getDoctorName();
+  }
+
+
+  onMounted(
+      getDoctorName
+  )
+
+</script>
+
+<template>
+
+  <div class="container">
+    <div class="my-3">
+      <span v-cloak>{{doctorName.name}}</span>
+    </div>
+  </div>
+
+
+</template>

--- a/frontend/src/views/reception/WaitingListDoctorName.vue
+++ b/frontend/src/views/reception/WaitingListDoctorName.vue
@@ -1,22 +1,8 @@
 <script setup>
-import {onMounted, reactive} from "vue";
-import {reception} from "@/util/reception.js";
 
-const doctorName = reactive({
-
-  name: null
-
-});
-
-const getDoctorName = async () => {
-
-  doctorName.name = await reception.getDoctorName();
-
-}
-
-onMounted(
-    getDoctorName
-)
+defineProps({
+  value: Object
+})
 
 </script>
 
@@ -24,10 +10,7 @@ onMounted(
 
   <div class="container">
     <div class="my-3">
-      <span v-cloak>{{doctorName.name}}</span>
-    </div>
-    <div class="my-3">
-
+      <span v-cloak>{{value.name}}</span>
     </div>
   </div>
 

--- a/frontend/src/views/reception/WaitingListDoctorName.vue
+++ b/frontend/src/views/reception/WaitingListDoctorName.vue
@@ -1,0 +1,34 @@
+<script setup>
+import {onMounted, reactive} from "vue";
+import {reception} from "@/util/reception.js";
+
+const doctorName = reactive({
+
+  name: null
+
+});
+
+const getDoctorName = async () => {
+
+  doctorName.name = await reception.getDoctorName();
+
+}
+
+onMounted(
+    getDoctorName
+)
+
+</script>
+
+<template>
+
+  <div class="container">
+    <div class="my-3">
+      <span v-cloak>{{doctorName.name}}</span>
+    </div>
+    <div class="my-3">
+
+    </div>
+  </div>
+
+</template>

--- a/frontend/src/views/reception/WaitingListPatientList.vue
+++ b/frontend/src/views/reception/WaitingListPatientList.vue
@@ -4,11 +4,9 @@ import {reception} from "@/util/reception.js";
 
   const patientList = ref();
 
-  const doctorUuid = '550e8400-e29b-41d4-a716-446655440000';
-
   const getWaitingList = async () => {
     console.log("a");
-    patientList.value = await reception.getWaitingList(doctorUuid);
+    patientList.value = await reception.getWaitingList;
     console.log(patientList.value);
   }
 

--- a/frontend/src/views/reception/WaitingListPatientList.vue
+++ b/frontend/src/views/reception/WaitingListPatientList.vue
@@ -1,0 +1,34 @@
+<script setup>
+import {onMounted, ref} from "vue";
+import {reception} from "@/util/reception.js";
+
+  const patientList = ref();
+
+  const doctorUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  const getWaitingList = async () => {
+    console.log("a");
+    patientList.value = await reception.getWaitingList(doctorUuid);
+    console.log(patientList.value);
+  }
+
+  onMounted(
+      getWaitingList
+  )
+</script>
+
+<template>
+
+  <div class="container">
+    <div class="my-3">
+      <template v-for="patient in patientList" :key="patient.uuid">
+        <div>
+          <button class="btn btn-primary" type="submit" v-cloak>{{patient.name}}</button>
+          <input class="btn btn-primary" type="button" value="대기">
+        </div>
+
+      </template>
+    </div>
+  </div>
+
+</template>

--- a/frontend/src/views/reception/WaitingListPatientList.vue
+++ b/frontend/src/views/reception/WaitingListPatientList.vue
@@ -2,29 +2,26 @@
 import {onMounted, ref} from "vue";
 import {reception} from "@/util/reception.js";
 
-  const patientList = ref();
+defineProps({
+  value: Object
+})
 
-  const getWaitingList = async () => {
-    console.log("a");
-    patientList.value = await reception.getWaitingList;
-    console.log(patientList.value);
-  }
+const cancelReception = (uuid) => {
+  const response = reception.cancelReception(uuid);
+}
 
-  onMounted(
-      getWaitingList
-  )
 </script>
 
 <template>
 
   <div class="container">
     <div class="my-3">
-      <template v-for="patient in patientList" :key="patient.uuid">
+      <template v-for="patient in value" :key="patient.uuid">
         <div>
           <button class="btn btn-primary" type="submit" v-cloak>{{patient.name}}</button>
           <input class="btn btn-primary" type="button" value="대기">
+          <button class="btn btn-primary" type="submit" @click="cancelReception(patient.uuid)">취소</button>
         </div>
-
       </template>
     </div>
   </div>

--- a/server/src/main/java/com/emr/slgi/doctor/DoctorController.java
+++ b/server/src/main/java/com/emr/slgi/doctor/DoctorController.java
@@ -9,6 +9,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +32,8 @@ public class DoctorController {
         return ResponseEntity.status(HttpStatus.OK).body(Map.of("list", list));
     }
 
-
+    @GetMapping("/{uuid}/name")
+    public ResponseEntity<?> getDoctorName(@PathVariable("uuid") String uuid) {
+        return ResponseEntity.ok().body(Map.of("name", memberService.getDoctorName(uuid)));
+    }
 }

--- a/server/src/main/java/com/emr/slgi/member/MemberDAO.java
+++ b/server/src/main/java/com/emr/slgi/member/MemberDAO.java
@@ -14,4 +14,5 @@ public interface MemberDAO {
     public List<Member> getStaffList(String uuid);
     public List<Member> search(MemberSearchDTO memberSearchDTO);
     public void createPatient(MemberCreateDTO memberCreateDTO);
+    public String getDoctorName(String uuid);
 }

--- a/server/src/main/java/com/emr/slgi/member/MemberService.java
+++ b/server/src/main/java/com/emr/slgi/member/MemberService.java
@@ -2,7 +2,9 @@ package com.emr.slgi.member;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,5 +19,13 @@ public class MemberService {
 
     public List<Member> getDoctorList() {
         return memberDAO.getDoctorList();
+    }
+
+    public String getDoctorName(String uuid) {
+        String name = memberDAO.getDoctorName(uuid);
+        if (name == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "의사를 찾을 수 없습니다.");
+        }
+        return name;
     }
 }

--- a/server/src/main/java/com/emr/slgi/reception/controller/ReceptionController.java
+++ b/server/src/main/java/com/emr/slgi/reception/controller/ReceptionController.java
@@ -4,14 +4,20 @@ import com.emr.slgi.reception.dto.ReceptionInfo;
 import com.emr.slgi.reception.service.ReceptionService;
 import com.emr.slgi.reception.service.WaitingList;
 import com.emr.slgi.util.CommonErrorMessage;
+import com.emr.slgi.util.ReceptionErrorMessage;
+import com.emr.slgi.util.ReservationErrorMessage;
+import com.emr.slgi.util.Validate;
+import jakarta.validation.Path;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -33,13 +39,45 @@ public class ReceptionController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/getWaitingList")
-    public ResponseEntity<Map<String, List<WaitingList>>> getWaitingList() {
+    @PreAuthorize("hasAnyRole('DOCTOR', 'NURSE')")
+    @GetMapping("/getWaitingList/{doctorUuid}")
+    public ResponseEntity<Map<String, List<WaitingList>>> getWaitingList(
+            @PathVariable("doctorUuid") String doctorUuid
+    ) {
 
-        List<WaitingList> list = receptionService.getWaitingList();
+        List<WaitingList> list = receptionService.getWaitingList(doctorUuid);
 
         return ResponseEntity.ok(
                 Map.of("waitingList", list)
+        );
+
+    }
+
+    @PreAuthorize("hasAnyRole('DOCTOR', 'NURSE')")
+    @GetMapping("/getDoctorName/{uuid}/{role}")
+    public ResponseEntity<Map<String, String>> getDoctorName(
+            @PathVariable("uuid") String uuid,
+            @PathVariable("role") String role) {
+
+        String name;
+
+        if(Validate.regexValidate(Map.of(Validate.MEMBER_UUID_REGEX, uuid)).contains(false)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ReceptionErrorMessage.CAN_NOT_FIND_DATA);
+        }
+
+        if(role == "R002") {
+            name = receptionService.getDoctorNameByDoctor(uuid);
+        }else {
+            // String 대신 Map 사용?
+            name = receptionService.getDoctorNameByNurse();
+        }
+
+        if(name.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ReceptionErrorMessage.CAN_NOT_FIND_DATA);
+        }
+
+        return ResponseEntity.ok(
+                Map.of("name", name)
         );
 
     }

--- a/server/src/main/java/com/emr/slgi/reception/controller/ReceptionController.java
+++ b/server/src/main/java/com/emr/slgi/reception/controller/ReceptionController.java
@@ -44,40 +44,12 @@ public class ReceptionController {
     public ResponseEntity<Map<String, List<WaitingList>>> getWaitingList(
             @PathVariable("doctorUuid") String doctorUuid
     ) {
-
+        log.info(doctorUuid);
+        log.info("a");
         List<WaitingList> list = receptionService.getWaitingList(doctorUuid);
-
+        System.out.println(list.toString());
         return ResponseEntity.ok(
                 Map.of("waitingList", list)
-        );
-
-    }
-
-    @PreAuthorize("hasAnyRole('DOCTOR', 'NURSE')")
-    @GetMapping("/getDoctorName/{uuid}/{role}")
-    public ResponseEntity<Map<String, String>> getDoctorName(
-            @PathVariable("uuid") String uuid,
-            @PathVariable("role") String role) {
-
-        String name;
-
-        if(Validate.regexValidate(Map.of(Validate.MEMBER_UUID_REGEX, uuid)).contains(false)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ReceptionErrorMessage.CAN_NOT_FIND_DATA);
-        }
-
-        if(role == "R002") {
-            name = receptionService.getDoctorNameByDoctor(uuid);
-        }else {
-            // String 대신 Map 사용?
-            name = receptionService.getDoctorNameByNurse();
-        }
-
-        if(name.isEmpty()) {
-            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ReceptionErrorMessage.CAN_NOT_FIND_DATA);
-        }
-
-        return ResponseEntity.ok(
-                Map.of("name", name)
         );
 
     }

--- a/server/src/main/java/com/emr/slgi/reception/controller/ReceptionController.java
+++ b/server/src/main/java/com/emr/slgi/reception/controller/ReceptionController.java
@@ -11,6 +11,8 @@ import jakarta.validation.Path;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
+import org.springframework.boot.autoconfigure.graphql.GraphQlProperties;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -29,7 +31,7 @@ public class ReceptionController {
 
     private final ReceptionService receptionService;
 
-    @PostMapping
+    @PostMapping("/acceptPatientByStaff")
     public ResponseEntity<?> acceptPatientByStaff(@RequestBody @Valid ReceptionInfo receptionInfo) {
 
         if(receptionService.acceptPatientByStaff(receptionInfo) != 1) {
@@ -40,7 +42,7 @@ public class ReceptionController {
     }
 
     @PreAuthorize("hasAnyRole('DOCTOR', 'NURSE')")
-    @GetMapping("/getWaitingList/{doctorUuid}")
+    @GetMapping("/{doctorUuid}")
     public ResponseEntity<Map<String, List<WaitingList>>> getWaitingList(
             @PathVariable("doctorUuid") String doctorUuid
     ) {
@@ -51,6 +53,18 @@ public class ReceptionController {
         return ResponseEntity.ok(
                 Map.of("waitingList", list)
         );
+
+    }
+
+    @PreAuthorize("hasAnyRole('DOCTOR', 'NURSE')")
+    @PutMapping("/{uuid}/cancel")
+    public ResponseEntity<?> cancelReception(@PathVariable("uuid") String uuid) {
+
+        if(receptionService.cancelReception(uuid) != 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, CommonErrorMessage.RETRY);
+        }
+
+        return ResponseEntity.ok().build();
 
     }
 

--- a/server/src/main/java/com/emr/slgi/reception/dao/ReceptionDAO.java
+++ b/server/src/main/java/com/emr/slgi/reception/dao/ReceptionDAO.java
@@ -13,9 +13,4 @@ public interface ReceptionDAO {
 
     List<WaitingList> getWaitingList(String doctorUuid);
 
-    // 팀장님께 Member 테이블 코드 작성 요청하기.
-    String getDoctorNameByDoctor(String uuid);
-
-    String getDoctorNameByNurse();
-
 }

--- a/server/src/main/java/com/emr/slgi/reception/dao/ReceptionDAO.java
+++ b/server/src/main/java/com/emr/slgi/reception/dao/ReceptionDAO.java
@@ -13,4 +13,6 @@ public interface ReceptionDAO {
 
     List<WaitingList> getWaitingList(String doctorUuid);
 
+    int cancelReception(String uuid);
+
 }

--- a/server/src/main/java/com/emr/slgi/reception/dao/ReceptionDAO.java
+++ b/server/src/main/java/com/emr/slgi/reception/dao/ReceptionDAO.java
@@ -11,5 +11,11 @@ public interface ReceptionDAO {
 
     public int acceptPatientByStaff(ReceptionInfo receptionInfo);
 
-    List<WaitingList> getWaitingList();
+    List<WaitingList> getWaitingList(String doctorUuid);
+
+    // 팀장님께 Member 테이블 코드 작성 요청하기.
+    String getDoctorNameByDoctor(String uuid);
+
+    String getDoctorNameByNurse();
+
 }

--- a/server/src/main/java/com/emr/slgi/reception/service/ReceptionService.java
+++ b/server/src/main/java/com/emr/slgi/reception/service/ReceptionService.java
@@ -30,4 +30,9 @@ public class ReceptionService {
 
     }
 
+    public int cancelReception(String uuid) {
+
+        return receptionDAO.cancelReception(uuid);
+
+    }
 }

--- a/server/src/main/java/com/emr/slgi/reception/service/ReceptionService.java
+++ b/server/src/main/java/com/emr/slgi/reception/service/ReceptionService.java
@@ -19,14 +19,26 @@ public class ReceptionService {
         return receptionDAO.acceptPatientByStaff(receptionInfo);
     }
 
-    public List<WaitingList> getWaitingList() {
+    public List<WaitingList> getWaitingList(String doctorUuid) {
 
-        List<WaitingList> waitingList = receptionDAO.getWaitingList();
+        List<WaitingList> waitingList = receptionDAO.getWaitingList(doctorUuid);
 
 //        현재 대기중인 환자 리스트에 진료 중인 환자 진료 테이블에 가져와서 추가. 함수명은 임의로 작성.
 //        waitingList.add(tDAO.getTreatingPatientInfo());
 
         return waitingList;
+
+    }
+
+    public String getDoctorNameByDoctor(String uuid) {
+
+        return receptionDAO.getDoctorNameByDoctor(uuid);
+
+    }
+
+    public String getDoctorNameByNurse() {
+
+        return receptionDAO.getDoctorNameByNurse();
 
     }
 

--- a/server/src/main/java/com/emr/slgi/reception/service/ReceptionService.java
+++ b/server/src/main/java/com/emr/slgi/reception/service/ReceptionService.java
@@ -30,16 +30,4 @@ public class ReceptionService {
 
     }
 
-    public String getDoctorNameByDoctor(String uuid) {
-
-        return receptionDAO.getDoctorNameByDoctor(uuid);
-
-    }
-
-    public String getDoctorNameByNurse() {
-
-        return receptionDAO.getDoctorNameByNurse();
-
-    }
-
 }

--- a/server/src/main/java/com/emr/slgi/reception/service/WaitingList.java
+++ b/server/src/main/java/com/emr/slgi/reception/service/WaitingList.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 @Data
 public class WaitingList {
 
+    private String uuid;
     private String patientUuid;
     private String status;
     private String name;

--- a/server/src/main/java/com/emr/slgi/reception/service/WaitingList.java
+++ b/server/src/main/java/com/emr/slgi/reception/service/WaitingList.java
@@ -2,16 +2,15 @@ package com.emr.slgi.reception.service;
 
 import lombok.Data;
 
+import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 @Data
 public class WaitingList {
 
     private String patientUuid;
-    private String doctorUuid;
     private String status;
     private String name;
-    private String rrn;
-    private OffsetDateTime createDate;
+    private LocalDateTime createDate;
 
 }

--- a/server/src/main/java/com/emr/slgi/util/ReceptionErrorMessage.java
+++ b/server/src/main/java/com/emr/slgi/util/ReceptionErrorMessage.java
@@ -3,5 +3,6 @@ package com.emr.slgi.util;
 public class ReceptionErrorMessage {
 
     public static final String RRN_NOT_NULL = "유효한 주민등록번호를 입력해주세요.";
+    public static final String CAN_NOT_FIND_DATA = "데이터를 찾을 수 없습니다.";
 
 }

--- a/server/src/main/resources/mappers/member.xml
+++ b/server/src/main/resources/mappers/member.xml
@@ -23,6 +23,13 @@
     FROM TB_MEMBER
     WHERE member_role = 'R002'
   </select>
+  <select id="getDoctorName">
+    SELECT name
+    FROM TB_MEMBER
+    WHERE
+      member_role = 'R002'
+      AND uuid=#{uuid}
+  </select>
   <select id="getStaffList">
     SELECT
       uuid,

--- a/server/src/main/resources/mappers/reception.xml
+++ b/server/src/main/resources/mappers/reception.xml
@@ -31,6 +31,8 @@
         FROM
             TB_RECEPTION
         WHERE
+            DOCTOR_UUID = #{doctorUuid}
+            AND
             STATUS IN ('RE01')
     </select>
 

--- a/server/src/main/resources/mappers/reception.xml
+++ b/server/src/main/resources/mappers/reception.xml
@@ -27,7 +27,7 @@
 
     <select id="getWaitingList">
         SELECT
-            PATIENT_UUID, DOCTOR_UUID, STATUS, NAME, RRN, CREATE_DATE
+            PATIENT_UUID, NAME
         FROM
             TB_RECEPTION
         WHERE

--- a/server/src/main/resources/mappers/reception.xml
+++ b/server/src/main/resources/mappers/reception.xml
@@ -27,13 +27,27 @@
 
     <select id="getWaitingList">
         SELECT
-            PATIENT_UUID, NAME
+            UUID, PATIENT_UUID, NAME, CREATE_DATE
         FROM
             TB_RECEPTION
         WHERE
             DOCTOR_UUID = #{doctorUuid}
             AND
             STATUS IN ('RE01')
+--         오늘 날짜만 조회하기 위해 설정했지만 테스트위해 일단 생략
+--             AND
+--             CREATE_DATE BETWEEN CURDATE() AND CURDATE() + INTERVAL 1 DAY
+        ORDER BY
+            CREATE_DATE;
     </select>
+
+    <update id="cancelReception">
+        UPDATE
+            TB_RECEPTION
+        SET
+            STATUS = 'RE02'
+        WHERE
+            UUID = #{uuid}
+    </update>
 
 </mapper>

--- a/server/src/main/resources/mappers/reception.xml
+++ b/server/src/main/resources/mappers/reception.xml
@@ -27,7 +27,7 @@
 
     <select id="getWaitingList">
         SELECT
-            UUID, PATIENT_UUID, NAME, CREATE_DATE
+            UUID, PATIENT_UUID, NAME, STATUS, CREATE_DATE
         FROM
             TB_RECEPTION
         WHERE


### PR DESCRIPTION
# 작업 내용
## 의료진용 환자 대기 리스트 구현
- 의사 이름 표시하는 컴포넌트와 의사별 대기 환자 목록 컴포넌트로 구분.
- 부모 컴포넌트의 onBeforeMount 생명 주기에 의사별 환자 목록 저장(Pinia).
`
import {useWaitingListStore} from "@/stores/waitingListStore.js";
const 변수명 = useWaitingListStore();
`
- 클라이언트에 필요한 데이터들만 가져오도록 쿼리문 수정.
- WaitingList.vue에 웹소켓 연결부 작성해 사용할 것.


# 추가사항
- 추후 STATUS 변경(진료 중) 추가 예정