### PR TITLE
접수 테이블 Mapper 초안 및 WaitingList.vue의 불필요한 import 때문에 발생한 에러 해결

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -54,13 +54,6 @@ const router = createRouter({
       name : 'chatroom',
       component:ChatRoom
     },
-
-
-    {
-      path: '/medicalTreatment',
-      name : 'medicalTreatment',
-      component:MedicalTreatment
-    },
     {
       path: '/acceptPatientByStaff',
       name: 'acceptPatientByStaff',
@@ -73,7 +66,13 @@ const router = createRouter({
       children: [
           ...receptionRoutes
       ]
-    }
+    },
+    {
+      path: '/medicalTreatment',
+      name : 'medicalTreatment',
+      component:MedicalTreatment
+    },
+
   ],
 })
 

--- a/frontend/src/views/reception/WaitingList.vue
+++ b/frontend/src/views/reception/WaitingList.vue
@@ -1,7 +1,6 @@
 <script setup>
   import {useWaitingListStore} from "@/stores/waitingListStore.js";
   import {onBeforeMount, onMounted, onUnmounted, ref} from "vue";
-  import WaitingListPerDoctor from "@/views/reception/WaitingListPerDoctor.vue";
   import WaitingListDoctorName from "@/views/reception/WaitingListDoctorName.vue";
   import WaitingListPatientList from "@/views/reception/WaitingListPatientList.vue";
 

--- a/server/src/main/java/com/emr/slgi/reception/enums/ReceptionStatus.java
+++ b/server/src/main/java/com/emr/slgi/reception/enums/ReceptionStatus.java
@@ -1,0 +1,28 @@
+package com.emr.slgi.reception.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReceptionStatus {
+
+    WAITING("RE01", "대기"),
+    CANCELRECEPTION("RE02", "접수 취소"),
+    RECEPTIONCOMPLETE("RE03", "접수 완료");
+
+    private final String code;
+    private final String status;
+
+    private static final Map<String, ReceptionStatus> Mapper =
+            Arrays.stream(values()).collect(Collectors.toMap(ReceptionStatus::getCode, e -> e));
+
+//    public static ReceptionStatus fromCode(Object o) {
+//
+//    }
+
+}


### PR DESCRIPTION
# 작업 내용
## WaitingList.vue 내 불필요한 import문 제거
- 이전 PR에서 삭제한 import문과 별개로 추가 삭제해야 
reception 라우터 이용해 이동시 동작.
- https://github.com/MSA-2025-1/msa-medical/pull/39#issue-3185770225

## 접수 테이블 Mapper 초안
- STATUS를 코드에서 상태명으로 변경할 ENUM 작성.
- 현재는 동작하지 않는 상태.