### PR TITLE
액세스 토큰 재발급 함수 분리

### DIFF
--- a/frontend/src/auth/renewAccessToken.js
+++ b/frontend/src/auth/renewAccessToken.js
@@ -1,0 +1,38 @@
+import axios from "axios";
+import { getRefreshToken } from "./refreshToken";
+import { setAccessToken } from "./accessToken";
+import { ENDPOINTS } from "@/util/endpoints";
+
+const instance = axios.create({
+  baseURL: '/api'
+});
+
+async function renewAccessTokenInternal() {
+  const refreshToken = getRefreshToken();
+  if (!refreshToken) {
+    throw new Error("토큰이 없습니다.");
+  }
+  const response = await instance({
+    ...ENDPOINTS.auth.refreshToken,
+    data: { refreshToken: getRefreshToken() }
+  });
+  setAccessToken(response.data.accessToken);
+}
+
+let isRefreshing = false;
+let refreshPromise = null;
+
+export async function renewAccessToken() {
+  if (isRefreshing) {
+    return refreshPromise;
+  }
+
+  isRefreshing = true;
+  refreshPromise = renewAccessTokenInternal();
+  try {
+    await refreshPromise;
+  } finally {
+    isRefreshing = false;
+    refreshPromise = null;
+  }
+}


### PR DESCRIPTION
## 작업 내용
# 액세스 토큰 재발급 함수 분리
- 재발급 동작을 함수로 분리해서 어떤 위치에서 재발급을 해도 재발급 중에는 다시 재발급을 요청하지 않고 기존의 재발급을 기다리도록 변경
- Promise 객체를 반환하는 것으로 큐 방식을 제거