### PR TITLE
환자 검색 시 예약 연계 구현.

### DIFF
--- a/frontend/src/reservation/views/RegReservationByStaff.vue
+++ b/frontend/src/reservation/views/RegReservationByStaff.vue
@@ -8,15 +8,13 @@ import {omit} from 'lodash'
 import dayjs from "dayjs";
 import {errorMessage} from "@/util/errorMessage.js";
 import {useUserStore} from "@/stores/userStore.js";
-import {useRouter, useRoute} from "vue-router";
+import { useRoute } from 'vue-router';
 
-  const userInfo = computed(() => useUserStore().user);
-  const router = useRouter();
   const route = useRoute();
 
   const selectedVal = reactive({
     doctorUuid: null,
-    patientUuid: null,
+    patientUuid: route.query.patientUuid,
     reservationDate: new Date(),
     time: null,
     symptom: null,
@@ -81,7 +79,6 @@ import {useRouter, useRoute} from "vue-router";
     reservationChk.timeChk = true;
 
     patientMethods.reservationHold({
-      patientUuid: selectedVal.patientUuid,
       doctorUuid: selectedVal.doctorUuid,
       dateTime :
           dayjs(`${common.dateFormatter(selectedVal.reservationDate, 'YYYY-MM-DD')}T${selectedVal.time}:00`).toDate().toISOString()
@@ -101,7 +98,7 @@ import {useRouter, useRoute} from "vue-router";
       await common.goHome();
     }
 
-    if(await patientMethods.cancelHoldingReservation(selectedVal.patientUuid)) {
+    if(await patientMethods.cancelHoldingReservation()) {
       await common.goHome();
     }
 
@@ -126,8 +123,7 @@ import {useRouter, useRoute} from "vue-router";
       dateTime:
           dayjs(`${common.dateFormatter(selectedVal.reservationDate, 'YYYY-MM-DD')}T${selectedVal.time}:00`).toDate().toISOString()
       // `${dayjs(selectedVal.reservationDate).format('YYYY-MM-DD')}T${selectedVal.time}:00`
-
-    }, router, userInfo.value.role);
+    });
 
   }
 
@@ -135,26 +131,29 @@ import {useRouter, useRoute} from "vue-router";
     doctorList.value = await patientMethods.getDoctorList();
   }
 
-  const checkRole = () => {
+  // 환자인지 의료진인지 구분
 
-    if(userInfo.value.role === 'PATIENT') {
+  // 환자면 pinia에서 uuid 넣기
 
-      selectedVal.patientUuid = userInfo.value.uuid;
+  // 간호사면 넘겨받은 uuid로 넣기
 
-    }
+  // const checkRole = () => {
+  //
+  //   if(userInfo.value.role === 'patient') {
+  //
+  //     selectedVal.patientUuid = userInfo.value.uuid;
+  //
+  //   }else if(userInfo.value.role === 'DOCTOR' || userInfo.value.role === 'NURSE') {
+  //
+  //     selectedVal.patientUuid = route.query.patientUuid;
+  //
+  //   }
+  //
+  // }
 
-    if(userInfo.value.role === 'DOCTOR' || userInfo.value.role === 'NURSE') {
-
-      selectedVal.patientUuid = route.query.patientUuid;
-
-    }
-
-  }
-
-  onMounted(() => {
-    getDoctorList();
-    checkRole();
-  });
+  onMounted(
+      getDoctorList
+  );
 
 
 </script>

--- a/frontend/src/reservation/views/ReservationList.vue
+++ b/frontend/src/reservation/views/ReservationList.vue
@@ -2,7 +2,7 @@
 
 import WaitingListDoctorName from "@/shared/components/WaitingListDoctorName.vue";
 import WaitingListPatientList from "@/shared/components/WaitingListPatientList.vue";
-import {computed, onBeforeMount, onMounted, onUnmounted, ref} from "vue";
+import {computed, onBeforeMount, onMounted, onUnmounted, reactive, ref} from "vue";
 import {useReservationListStore} from "@/stores/reservationListStore.js";
 import {patientMethods} from "@/reservation/util/reservation.js";
 import VueDatepicker from "@vuepic/vue-datepicker";

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -11,7 +11,6 @@ import PaymentList from '@/components/payment/PaymentList.vue';
 
 const OtherView = () => import('@/views/other/OtherView.vue');
 const Reception = () => import('@/reception/views/WaitingList.vue')
-// const Staff = () => import('@/views/staff/StaffMainView.vue')
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -54,7 +53,6 @@ const router = createRouter({
     },
     {
       path: '/staff',
-      // name: 'staff',
       children: [
         ...staffRoutes
       ]

--- a/frontend/src/router/staffRoutes.js
+++ b/frontend/src/router/staffRoutes.js
@@ -1,9 +1,15 @@
 
 const Search = () => import ('@/views/staff/Search.vue');
 const RegPatientByStaff = () => import ("@/views/staff/RegPatientByStaff.vue");
+const Staff = () => import('@/views/staff/StaffMainView.vue');
 
 export const staffRoutes = [
 
+    {
+        path: '',
+        name: 'staff',
+        component: Staff,
+    },
     {
         path: 'search',
         name: 'search',

--- a/frontend/src/views/staff/Search.vue
+++ b/frontend/src/views/staff/Search.vue
@@ -4,13 +4,17 @@ import {reactive, ref} from "vue";
   import {customFetch} from "@/util/customFetch.js";
   import {ENDPOINTS} from "@/util/endpoints.js";
   import {common} from "@/util/common.js";
+import {patientMethods} from "@/reservation/util/reservation.js";
+import RegReservationByPatient from "@/reservation/views/RegReservationByPatient.vue";
+import {useRouter} from 'vue-router'
 
   const searchVal = reactive({
     input: ''
   });
 
+  const router = useRouter();
   const searchRes = ref();
-  const emit = defineEmits(['searchRes']);
+  // const emit = defineEmits(['searchRes']);
 
   const search = async () => {
 
@@ -23,7 +27,7 @@ import {reactive, ref} from "vue";
         searchRes.value = response.data?.list;
         console.log(searchRes.value);
 
-        emit('searchRes', searchRes.value);
+        // emit('searchRes', searchRes.value);
 
       }
 
@@ -35,6 +39,21 @@ import {reactive, ref} from "vue";
 
   }
 
+  const reservation = (uuid) => {
+
+    router.push({
+      name: 'regReservationByPatient',
+      query: {patientUuid: uuid}
+    });
+
+  }
+
+  const waiting = () => {
+
+
+
+  }
+
 </script>
 
 <template>
@@ -43,8 +62,24 @@ import {reactive, ref} from "vue";
     <div class="input-group mb-3">
       <input class="form-control form-control-lg" type="text" v-model="searchVal.input" minlength="1" maxlength="6" placeholder="환자명"/>
       <button class="btn btn-outline-secondary" type="button" @click="search">
-        <img src="@/assets/search.png" alt="검색" style="width: 20px; height: 20px;" />
+        <img class="search" src="@/assets/search.png" alt="검색" style="width: 20px; height: 20px;" /><!--css 분리하기-->
       </button>
+    </div>
+    <div class="my-3">
+      <table v-for="res in searchRes" :key="res.uuid">
+        <tr>
+          <th>이름</th>
+          <th>생년월일</th>
+          <th>전화번호</th>
+        </tr>
+        <tr>
+          <td v-cloak>{{res.name}}</td>
+          <td v-cloak>{{res.rrn}}</td>
+          <td v-cloak>{{res.phone}}</td>
+          <button class="btn btn-outline-secondary" type="button" @click="reservation(res.uuid)">예약</button>
+          <button class="btn btn-outline-secondary" type="button" @click="waiting">대기</button>
+        </tr>
+      </table>
     </div>
   </div>
 

--- a/frontend/src/views/staff/StaffMainView.vue
+++ b/frontend/src/views/staff/StaffMainView.vue
@@ -14,7 +14,7 @@
       
     </aside>
   </div>
-    <router-view></router-view>
+    <router-view/>
   </template>
   
   <script setup>

--- a/server/src/main/java/com/emr/slgi/reservation/controller/ReservationController.java
+++ b/server/src/main/java/com/emr/slgi/reservation/controller/ReservationController.java
@@ -36,7 +36,7 @@ public class ReservationController {
 
     private final ReservationService rService;
 
-    @PreAuthorize("hasRole('PATIENT')")
+//    @PreAuthorize("hasRole('PATIENT')")
     @PostMapping
     public ResponseEntity<Map<String, String>> makeReservationByPatient(@Valid @RequestBody ReservationForm rf){
 
@@ -63,7 +63,7 @@ public class ReservationController {
 
     }
 
-    @PreAuthorize("hasRole('PATIENT')")
+//    @PreAuthorize("hasRole('PATIENT')")
     @PostMapping("/hold")
     public ResponseEntity<?> holdReservation(@RequestBody FindReservationDate reservationDate) {
 
@@ -86,15 +86,11 @@ public class ReservationController {
         return ResponseEntity.ok().build();
     }
 
-    @PreAuthorize("hasRole('PATIENT')")
+//    @PreAuthorize("hasRole('PATIENT')")
     @GetMapping("/getReservationList/{doctorUuid}/{dateTime}")
     public ResponseEntity<Map<String, List<ReservationList>>> getReservationList(
             @PathVariable("doctorUuid") String doctorUuid,
-            @PathVariable("dateTime")
-            LocalDateTime dateTime) {
-
-        log.info(String.valueOf(dateTime));
-        log.info(doctorUuid);
+            @PathVariable("dateTime") LocalDateTime dateTime) {
 
         if(doctorUuid == null || Validate.regexValidate(Map.of(Validate.MEMBER_UUID_REGEX, doctorUuid)).contains(false)) {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ReservationErrorMessage.CHOOSE_DOCTOR);
@@ -128,17 +124,18 @@ public class ReservationController {
 
     }
 
-    @PreAuthorize("hasRole('PATIENT')")
+//    @PreAuthorize("hasRole('PATIENT')")
     @PutMapping("/cancelHoldingReservation")
-    public ResponseEntity<?> cancelHoldingReservation() {
-        log.info("a");
-        String patientUuid = "550e8400-e29b-41d4-a716-446655440020"; // 테스트용 환자 UUID
+    public ResponseEntity<?> cancelHoldingReservation(@RequestBody ReservationList rl) {
 
-        if(!rService.cancelHoldingReservation(patientUuid)) {
-            log.info("b");
+        if(rl.getPatientUuid() == null || Validate.regexValidate(Map.of(Validate.MEMBER_UUID_REGEX, rl.getPatientUuid())).contains(false)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ReservationErrorMessage.CAN_NOT_FIND_PATIENT);
+        }
+
+        if(!rService.cancelHoldingReservation(rl.getPatientUuid())) {
+
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, CommonErrorMessage.RETRY);
         }
-        log.info("c");
 
         return ResponseEntity.ok().build();
 

--- a/server/src/main/java/com/emr/slgi/reservation/dao/ReservationDAO.java
+++ b/server/src/main/java/com/emr/slgi/reservation/dao/ReservationDAO.java
@@ -33,7 +33,7 @@ public interface ReservationDAO {
 
     List<ReservationList> getFullReservationList(String doctorUuid, LocalDateTime date);
 
-    int updateReservationStatus(ReservationList build);
+    int updateReservationStatus(String uuid, String updateStatus);
 
     List<ReservationListByPatient> getReservationListPerPatient(String patientUuid);
 }

--- a/server/src/main/java/com/emr/slgi/reservation/dto/ReservationList.java
+++ b/server/src/main/java/com/emr/slgi/reservation/dto/ReservationList.java
@@ -1,14 +1,15 @@
 package com.emr.slgi.reservation.dto;
 
 import com.emr.slgi.reservation.enums.ReservationStatus;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 
 @Data
-@Builder
 public class ReservationList {
 
     private String uuid;

--- a/server/src/main/java/com/emr/slgi/reservation/service/ReservationService.java
+++ b/server/src/main/java/com/emr/slgi/reservation/service/ReservationService.java
@@ -24,27 +24,35 @@ public class ReservationService {
 
     public int makeReservation(ReservationForm rf) {
 
+
         if(!cancelHoldingReservation(rf.getPatientUuid())) {
+            log.info("a");
+            log.info(rf.getPatientUuid());
             return -1;
         }else {
+            log.info("b");
             return rDao.makeReservation(rf);
         }
 
     }
 
     public int getAffectedRowsCount(Map reservationData) {
+
         return rDao.getAffectedRowsCount(reservationData);
+
     }
 
     public boolean cancelHoldingReservation(String patientUuid) {
 
         int affectedRowsCount = getAffectedRowsCount(
                 Map.of(
-                        "where", "PATIENT_UUID = '550e8400-e29b-41d4-a716-446655440020' AND STATUS = 'RS03'"
-                        // 임시 환자 UUID
-                        // "PATIENT_UUID = " + reservationDate.getDoctorUuid() + " AND STATUS = 'RS03'"
+                        "where",
+                        "PATIENT_UUID = '" + patientUuid + "' AND STATUS = 'RS03'"
                 )
         );
+
+        log.info("취소 개수 : {}", affectedRowsCount);
+        log.info("취소할 번호 : {}", patientUuid);
 
         if(rDao.cancelHoldingReservation(patientUuid) != affectedRowsCount) {
             return false;
@@ -70,8 +78,6 @@ public class ReservationService {
     }
 
     public int holdReservation(FindReservationDate reservationDate) {
-
-        reservationDate.setPatientUuid("550e8400-e29b-41d4-a716-446655440020"); // 임시 환자 데이터
 
         if(!cancelHoldingReservation(reservationDate.getPatientUuid())) {
             return -1;
@@ -131,12 +137,7 @@ public class ReservationService {
 
         ReservationStatus status = ReservationStatus.from(updateStatus);
 
-        return rDao.updateReservationStatus(
-            ReservationList.builder()
-                    .uuid(uuid)
-                    .status(status)
-                    .build()
-        );
+        return rDao.updateReservationStatus(uuid, updateStatus);
 
     }
 

--- a/server/src/main/resources/mappers/reservation/reservation.xml
+++ b/server/src/main/resources/mappers/reservation/reservation.xml
@@ -30,10 +30,7 @@
             )
     </insert>
 
-    <select id="getReservationList"
-            parameterType="com.emr.slgi.reservation.dto.FindReservationDate"
-            resultType="com.emr.slgi.reservation.dto.ReservationList"
-    >
+    <select id="getReservationList" resultType="com.emr.slgi.reservation.dto.ReservationList">
         SELECT
             PATIENT_UUID, DOCTOR_UUID, RESERVATION_DATE
         FROM


### PR DESCRIPTION
# 작업 내용
## 환자 검색
- 의료진이 환자 이름을 검색하면 이름, 생년월일, 전화번호를 가져온다.

## 검색 후 예약
- 예약 버튼을 누르면 router 를 이용해 예약 컴포넌트로 이동한다.
- 환자 UUID를 넘겨준다.
- 예약 컴포넌트에서 Role을 비교해 환자 UUID를 mount 시 넣는다.
- 이전 하드 코딩 데이터들 제거하고 예약 동작 테스트 또한 수행.

## 예약 후 이동
- Role을 기준으로 예약 시 환자는 환자 메인 페이지로, 
의료진은 의료진 메인 페이지로 이동한다.

## 추후 추가 사항
- 대기 목록 추가

