### PR TITLE
리프레시 토큰 회전

### DIFF
--- a/frontend/src/auth/renewAccessToken.js
+++ b/frontend/src/auth/renewAccessToken.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getRefreshToken } from "./refreshToken";
+import { getRefreshToken, setRefreshToken } from "./refreshToken";
 import { setAccessToken } from "./accessToken";
 import { ENDPOINTS } from "@/util/endpoints";
 
@@ -17,6 +17,7 @@ async function renewAccessTokenInternal() {
     data: { refreshToken: getRefreshToken() }
   });
   setAccessToken(response.data.accessToken);
+  setRefreshToken(response.data.refreshToken);
 }
 
 let isRefreshing = false;

--- a/server/src/main/java/com/emr/slgi/auth/dto/AccessTokenResponse.java
+++ b/server/src/main/java/com/emr/slgi/auth/dto/AccessTokenResponse.java
@@ -1,5 +1,0 @@
-package com.emr.slgi.auth.dto;
-
-public record AccessTokenResponse(
-    String accessToken
-) {}

--- a/server/src/main/java/com/emr/slgi/auth/dto/TokenResponse.java
+++ b/server/src/main/java/com/emr/slgi/auth/dto/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.emr.slgi.auth.dto;
+
+public record TokenResponse(
+    String accessToken,
+    String refreshToken
+) {}

--- a/server/src/main/java/com/emr/slgi/auth/service/RefreshTokenService.java
+++ b/server/src/main/java/com/emr/slgi/auth/service/RefreshTokenService.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import com.emr.slgi.util.JwtUtil;
 
@@ -46,7 +48,9 @@ public class RefreshTokenService {
     public void whitelistTokenJti(String jti, Date exp) {
         String key = "whitelist:jti:" + jti;
         Duration remaining = Duration.between(Instant.now(), exp.toInstant());
-        remaining = remaining.isNegative() ? Duration.ZERO : remaining;
+        if (remaining.isNegative() || remaining.isZero()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다.");
+        }
         stringRedisTemplate.opsForValue().set(key, "1", remaining);
     }
 


### PR DESCRIPTION
# 작업 내용
## 리프레시 토큰 회전
- 리프레시 토큰으로 액세스 토큰을 재발급하면 기존의 리프레시 토큰을 비활성화하고 새로운 리프레시 토큰을 발급한다.
- 회전 방식 추가에 따라서 기존의 블랙리스트 방식보다 화이트 리스트 방식이 더 적절하다고 생각해서 화이트리스트 방식으로 변경