### PR TITLE
환자 예약 목록 버그 수정 및 선택 로직 추가

### DIFF
--- a/frontend/src/reservation/views/ReservationListByPatient.vue
+++ b/frontend/src/reservation/views/ReservationListByPatient.vue
@@ -20,8 +20,6 @@ import {errorMessage} from "@/util/errorMessage.js";
       selectedListByPatient.delete(e.target.value);
     }
 
-    console.log(selectedListByPatient);
-
   }
 
   const reservationListPerPatient = async () => {

--- a/frontend/src/reservation/views/ReservationListByPatient.vue
+++ b/frontend/src/reservation/views/ReservationListByPatient.vue
@@ -34,6 +34,10 @@ import {errorMessage} from "@/util/errorMessage.js";
       return;
     }
 
+    if(!window.confirm("예약 취소하시겠습니까?")) {
+      return;
+    }
+
     await patientMethods.cancelReservation(selectedListByPatient);
     selectedListByPatient.clear();
     await reservationListPerPatient();

--- a/frontend/src/reservation/views/ReservationListByPatient.vue
+++ b/frontend/src/reservation/views/ReservationListByPatient.vue
@@ -7,7 +7,6 @@ import {useUserStore} from "@/stores/userStore.js";
 import {common} from "@/util/common.js";
 import {errorMessage} from "@/util/errorMessage.js";
 
-  // 선택한 목록(들)
   const selectedListByPatient = new Set();
   const reservationList = ref();
   const userInfo = computed(() => useUserStore().user);

--- a/frontend/src/reservation/views/ReservationListByPatient.vue
+++ b/frontend/src/reservation/views/ReservationListByPatient.vue
@@ -4,6 +4,8 @@ import {computed, onMounted, reactive, ref} from "vue";
 import dayjs from "dayjs";
 import {patientMethods} from "@/reservation/util/reservation.js";
 import {useUserStore} from "@/stores/userStore.js";
+import {common} from "@/util/common.js";
+import {errorMessage} from "@/util/errorMessage.js";
 
   // 선택한 목록(들)
   const selectedListByPatient = new Set();
@@ -30,7 +32,14 @@ import {useUserStore} from "@/stores/userStore.js";
 
   const cancelReservation = async () => {
 
+    if(selectedListByPatient.size === 0) {
+      common.alertError(errorMessage.reservation.noDataForCancel);
+      return;
+    }
+
     await patientMethods.cancelReservation(selectedListByPatient);
+    selectedListByPatient.clear();
+    await reservationListPerPatient();
 
   }
 

--- a/frontend/src/util/errorMessage.js
+++ b/frontend/src/util/errorMessage.js
@@ -9,6 +9,9 @@ export const errorMessage = {
     },
     staff : {
         searchValLength: "검색어는 최소 1자 이상 입력해야합니다.",
+    },
+    reservation: {
+        noDataForCancel: "취소할 예약 일정을 선택해주세요."
     }
 
 }


### PR DESCRIPTION
# 작업 내용
## 환자 예약 목록 버그 수정
- 환자 예약 목록에서 선택 안하고 취소 버튼을 누를 경우,
빈 값으로 DB에 넘기던 문제 수정.
- 선택된 값이 있는지 검증하고, 있으면 넘기고 없으면 알림창 출력.

## 취소여부 확인 로직 추가
- 취소 버튼 누를 경우, 취소 여부를 다시 확인하는 알림창 띄우는 로직 추가.
- 알림창에서 취소를 누를 경우, 서버로 보내지 않고 실행 종료.