### PR TITLE
스웨거 프록시 설정, 시큐리티 필터 제외 처리

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -9,6 +9,19 @@ http {
 
     server {
         listen 80;
+
+        location = /api-docs {
+            proxy_pass http://was;
+        }
+
+        location ^~ /swagger-ui/ {
+            proxy_pass http://was;
+        }
+
+        location ^~ /v3/api-docs {
+            proxy_pass http://was;
+        }
+
         location /api/ {
             proxy_pass http://was/;
         }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -20,6 +20,18 @@ export default defineConfig({
   },
   server: {
     proxy: {
+      '/api-docs': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/swagger-ui': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/v3/api-docs': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
       "/api": {
         target: "http://localhost:8080",
         rewrite: (path) => path.replace(/^\/api/, ''),

--- a/server/src/main/java/com/emr/slgi/auth/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/emr/slgi/auth/filter/JwtAuthenticationFilter.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.emr.slgi.member.enums.MemberRole;
@@ -27,18 +26,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
-
     private final JwtUtil jwtUtil;
 
     @Value("${jwt.access-token-secret}")
     private String jwtSecret;
-
-    @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String path = request.getServletPath();
-        return pathMatcher.match("/auth/**", path);
-    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -25,15 +26,27 @@ import lombok.RequiredArgsConstructor;
 @EnableMethodSecurity
 public class SecurityConfig {
 
+    private static final String[] PUBLIC_URLS = {
+        "/auth/**",
+        "/error",
+        "/api-docs",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/ws/**"
+    };
+
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    WebSecurityCustomizer webSecurityCustomizer() {
+        return web -> web.ignoring().requestMatchers(PUBLIC_URLS);
+    }
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
             .csrf((csrf) -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/error", "/api-docs", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                .requestMatchers("/ws/**").permitAll()
                 .anyRequest().authenticated()
             )
             .exceptionHandling(exceptionHandling -> exceptionHandling

--- a/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
         return http
             .csrf((csrf) -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/auth/**", "/error").permitAll()
+                .requestMatchers("/auth/**", "/error", "/api-docs", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                 .requestMatchers("/ws/**").permitAll()
                 .anyRequest().authenticated()
             )


### PR DESCRIPTION
# 작업 내용
## 스웨거 문서에 대해서 프록시 설정 추가
- 프록시가 제대로 설정되어 있지 않아서 스웨거 경로로 이동 시에 문서가 나오지 않던 것 수정
## 시큐리티 필터 경로에서 스웨거 관련 경로 제외
- 커스텀 WebSecurityCustomizer 추가
- `/api-docs`, `/swagger-ui/**`, `/v3/api-docs/**`에 대해서 ignore 설정