### PR TITLE
의료진 네비게이션 가드 구현 및 예약 등록 시 라우트 수정

### DIFF
--- a/frontend/src/reservation/util/reservation.js
+++ b/frontend/src/reservation/util/reservation.js
@@ -1,10 +1,10 @@
 import {computed, ref} from 'vue'
 import {customFetch} from "@/util/customFetch.js";
 import {ENDPOINTS} from "@/util/endpoints.js";
-import { useRouter } from "vue-router";
 import {omit} from "lodash";
 import {common} from "@/util/common.js";
 import dayjs from "dayjs";
+import {roles} from "@/util/roles.js";
 
 export const patientMethods = {
     getReservationListPerPatient: async (uuid) => {
@@ -135,11 +135,11 @@ export const patientMethods = {
     },
     routeByRole : (role, router) => {
 
-        if(role === 'PATIENT') {
+        if(role === roles.PATIENT) {
             router.push({name: 'home'});
         }
 
-        if(role === 'DOCTOR' || role === 'NURSE') {
+        if(role === roles.DOCTOR || role === roles.NURSE) {
             router.push({name: 'staffMain'});
         }
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -3,21 +3,12 @@ import { patientRoutes } from './patientRoutes';
 import { adminRoutes } from './adminRoutes';
 import { staffRoutes } from './staffRoutes';
 
-const StaffLayOut = () => import('@/staff/layouts/StaffLayOut.vue')
-
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
     ...patientRoutes,
     ...adminRoutes,
-    {
-      path: '/staff',
-      component: StaffLayOut,
-      children: [
-        ...staffRoutes
-      ]
-    },
-
+    ...staffRoutes
   ],
 })
 

--- a/frontend/src/router/staffRoutes.js
+++ b/frontend/src/router/staffRoutes.js
@@ -13,9 +13,12 @@ export const staffRoutes = [
         component: StaffLayOut,
         beforeEnter: (to, from, next) => {
           const role = useUserStore().user?.role;
-          if ([roles.PATIENT].includes(role)) {
+          if ([roles.PATIENT].includes(role) || role === null || role === undefined) {
             return next({ name: 'home' });
           }
+        //   if(roles.ADMIN === role) {
+        //     return next({ name: 'adminMain' });
+        //   }
           next();
         },
         children: [

--- a/frontend/src/router/staffRoutes.js
+++ b/frontend/src/router/staffRoutes.js
@@ -1,28 +1,44 @@
+import { useUserStore } from "@/stores/userStore";
+import { roles } from "@/util/roles"; 
+
 const RegPatientByStaff = () => import ("@/staff/views/RegPatientByStaff.vue");
 const StaffMainView = () => import("@/staff/views/StaffMainView.vue");
 const RegReservationByStaff = () => import('@/reservation/views/RegReservationByStaff.vue')
 const AcceptPatientByStaff = () => import('@/staff/views/AcceptPatientByStaff.vue')
+const StaffLayOut = () => import('@/staff/layouts/StaffLayOut.vue')
 
 export const staffRoutes = [
-
     {
-        path: '',
-        name: 'staffMain',
-        component: StaffMainView,
+        path: '/staff',
+        component: StaffLayOut,
+        beforeEnter: (to, from, next) => {
+          const role = useUserStore().user?.role;
+          if ([roles.PATIENT].includes(role)) {
+            return next({ name: 'home' });
+          }
+          next();
+        },
+        children: [
+            {
+                path: '',
+                name: 'staffMain',
+                component: StaffMainView,
+            },
+            {
+                path: 'regReservationByStaff',
+                name: 'regReservationByStaff',
+                component: RegReservationByStaff,
+            },
+            {
+                path: 'regPatientByStaff',
+                name: 'regPatientByStaff',
+                component: RegPatientByStaff
+            },
+            {
+                path: 'acceptPatientByStaff',
+                name: 'acceptPatientByStaff',
+                component: AcceptPatientByStaff
+            }
+        ]
     },
-    {
-        path: 'regReservationByStaff',
-        name: 'regReservationByStaff',
-        component: RegReservationByStaff,
-    },
-    {
-        path: 'regPatientByStaff',
-        name: 'regPatientByStaff',
-        component: RegPatientByStaff
-    },
-    {
-        path: 'acceptPatientByStaff',
-        name: 'acceptPatientByStaff',
-        component: AcceptPatientByStaff
-    }
 ]

--- a/frontend/src/shared/views/RegReservation.vue
+++ b/frontend/src/shared/views/RegReservation.vue
@@ -100,11 +100,23 @@ import '@/assets/css/icons.css';
   const goHome = async () => {
 
     if(!reservationChk.timeChk) {
-      await common.goStaffHome();
+      routeToHome();
+      // await common.goStaffHome();
     }
 
     if(await patientMethods.cancelHoldingReservation(selectedVal.patientUuid)) {
-      await common.goStaffHome();
+      routeToHome();
+      // await common.goStaffHome();
+    }
+
+  }
+
+  const routeToHome = () => {
+
+    if(userInfo.value.role === roles.PATIENT) {
+      common.goHome();
+    } else {
+      common.goStaffHome();
     }
 
   }
@@ -129,6 +141,7 @@ import '@/assets/css/icons.css';
           dayjs(`${common.dateFormatter(selectedVal.reservationDate, 'YYYY-MM-DD')}T${selectedVal.time}:00`).toDate().toISOString()
 
     }, router, userInfo.value.role);
+
 
   }
 

--- a/frontend/src/shared/views/RegReservation.vue
+++ b/frontend/src/shared/views/RegReservation.vue
@@ -9,6 +9,7 @@ import dayjs from "dayjs";
 import {errorMessage} from "@/util/errorMessage.js";
 import {useUserStore} from "@/stores/userStore.js";
 import {useRouter, useRoute} from "vue-router";
+import {roles} from "@/util/roles.js";
 import '@/assets/css/RegReservation.css';
 import '@/assets/css/icons.css';
 
@@ -100,26 +101,24 @@ import '@/assets/css/icons.css';
   const goHome = async () => {
 
     if(!reservationChk.timeChk) {
-      routeToHome();
-      // await common.goStaffHome();
+      await routeToHome();
     }
 
     if(await patientMethods.cancelHoldingReservation(selectedVal.patientUuid)) {
-      routeToHome();
-      // await common.goStaffHome();
+      await routeToHome();
     }
 
   }
 
-  const routeToHome = () => {
+  const routeToHome = async() => {
 
     if(userInfo.value.role === roles.PATIENT) {
-      common.goHome();
+      await router.push({name: 'home'});
     } else {
-      common.goStaffHome();
+      await router.push({name: 'staffMain'});
     }
 
-  }
+}
 
   const reservation = () => {
     console.log(selectedVal.reservationDate);

--- a/frontend/src/staff/views/AcceptPatientByStaff.vue
+++ b/frontend/src/staff/views/AcceptPatientByStaff.vue
@@ -43,8 +43,8 @@ import '@/assets/css/icons.css'
 
   }
 
-  function goHome () {
-    common.goStaffHome();
+  async function goHome () {
+    await router.push({name: 'staffMain'});
   }
 
   async function getDoctorList () {

--- a/frontend/src/util/common.js
+++ b/frontend/src/util/common.js
@@ -3,12 +3,6 @@ import dayjs from "dayjs";
 
 export const common =  {
 
-    goHome : () => {
-        return router.push({name: 'home'});
-    },
-    goStaffHome: () => {
-        return router.push({name: 'staffMain'})
-    },
     goBack : () => {
         return router.back();
     },

--- a/frontend/src/util/roles.js
+++ b/frontend/src/util/roles.js
@@ -1,0 +1,6 @@
+export const roles = {
+    PATIENT: 'PATIENT',
+    ADMIN: 'ADMIN',
+    NURSE: 'NURSE',
+    DOCTOR: 'DOCTOR'
+}

--- a/frontend/src/util/roles.js
+++ b/frontend/src/util/roles.js
@@ -1,6 +1,7 @@
 export const roles = {
     PATIENT: 'PATIENT',
     ADMIN: 'ADMIN',
+    DOCTOR: 'DOCTOR',
     NURSE: 'NURSE',
     DOCTOR: 'DOCTOR'
 }

--- a/frontend/src/util/roles.js
+++ b/frontend/src/util/roles.js
@@ -1,7 +1,6 @@
 export const roles = {
     PATIENT: 'PATIENT',
     ADMIN: 'ADMIN',
-    DOCTOR: 'DOCTOR',
     NURSE: 'NURSE',
     DOCTOR: 'DOCTOR'
 }


### PR DESCRIPTION
# 작업 내용
## 의료진 네비게이션 가드 구현
- 의료진 외 ADMIN, PATIENT, 비로그인 시 staffRoutes 쪽에 라우트 할 경우, 정해진 route 로 강제 이동.
- ADMIN 은 아직 Route 가 없기 때문에 작성만 하고 주석 처리.

## 역할 재사용 가능하도록 role.js 작성
- ADMIN, DOCTOR, NURSE, PATIENT

## 예약 등록시 라우트 수정
- 취소 또는 등록 시 역할에 따라 라우트 분기.

## common.js 의 라우터 이용한 이동 삭제
- Router는 setup 내에서만 제대로 동작.
- 외부 js 에서는 router 를 매개변수로 줘야 동작.
- 불필요하다 판단해 사용 부분들 수정 후 삭제.

