### PR TITLE
부트스트랩 CSS 를 별도로 커스터마이징하지 않도록 수정

### DIFF
--- a/frontend/src/assets/css/RegReservation.css
+++ b/frontend/src/assets/css/RegReservation.css
@@ -1,201 +1,201 @@
 .reg-reservation-card {
-    max-width: 700px;
-    min-width: 500px;
-    margin: 40px auto;
-    background: #fff;
-    border-radius: 14px;
-    box-shadow: 0 2px 8px rgba(30, 64, 175, 0.06);
-    padding: 32px 28px 24px 28px;
-    border: 1px solid #f0f1f3;
-    font-family: 'Noto Sans KR', sans-serif;
-  }
-  
-  .reg-reservation-title {
-    font-size: 1.1rem;
-    font-weight: 600;
-    color: #222;
-    margin-bottom: 24px;
-    letter-spacing: -0.5px;
-  }
-  
-  .reg-reservation-form {
-    display: flex;
-    flex-direction: column;
-    gap: 22px;
-  }
-  
-  .reg-form-row {
-    display: flex;
-    flex-direction: column;
-    gap: 7px;
-  }
-  
-  .reg-form-label {
-    font-size: 1rem;
-    color: black;
-    font-weight: 400;
-    margin-bottom: 2px;
-    letter-spacing: -0.5px;
-  }
-  
-  .reg-required {
-    color: #e74c3c;
-    margin-left: 2px;
-    font-size: 1em;
-  }
-  
-  .reg-form-input {
-    border: 1.5px solid #e5e7eb;
-    border-radius: 7px;
-    padding: 9px 12px;
-    font-size: 1rem;
-    background: #f8fafc;
-    transition: border 0.2s;
-    outline: none;
-    resize: none;
-    width: 100%;
-    box-sizing: border-box;
-  }
-  
-  .reg-form-input:focus {
-    border-color: #2563eb;
-    background: #fff;
-  }
-  
-  .reg-dropdown-group {
-    position: relative;
-    width: 100%;
-  }
-  
-  .reg-dropdown-btn {
-    width: 100%;
-    background: #f8fafc;
-    border: 1.5px solid #e5e7eb;
-    border-radius: 7px;
-    padding: 9px 12px;
-    font-size: 1rem;
-    color: #222;
-    text-align: left;
-    cursor: pointer;
-    transition: border 0.2s;
-  }
-  
-  .reg-dropdown-btn:focus, .reg-dropdown-btn[aria-expanded='true'] {
-    border-color: #2563eb;
-    background: #fff;
-  }
-  
-  .reg-dropdown-menu {
-    position: absolute;
-    top: 110%;
-    left: 0;
-    width: 100%;
-    background: #fff;
-    border: 1px solid #e5e7eb;
-    border-radius: 8px;
-    box-shadow: 0 2px 8px rgba(30, 64, 175, 0.08);
-    z-index: 10;
-    padding: 4px 0;
-    margin: 0;
-    list-style: none;
-    display: none;
-  }
-  
-  .reg-dropdown-btn[aria-expanded='true'] + .reg-dropdown-menu {
-    display: block;
-  }
-  
-  .reg-dropdown-item {
-    padding: 8px 16px;
-    cursor: pointer;
-    color: black;
-    font-weight: 500;
-    transition: background 0.15s;
-    border-radius: 6px;
-  }
-  
-  .reg-dropdown-item:hover {
-    background: #e3eafc;
-  }
-  
-  .reg-time-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-  }
-  
-  .reg-btn-time {
-    background: #f3f4f6;
-    color: black;
-    border: 1.5px solid #e5e7eb;
-    border-radius: 7px;
-    padding: 7px 18px;
-    font-size: 1.2rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.2s, border 0.2s;
-  }
-  
-  .reg-btn-time:hover {
-    background: #e3eafc;
-    border-color: #e6f0ff;
-  }
-  
-  .reg-btn-time.active {
-    background: #2563eb;
-    color: #fff;
-    border-color: #2563eb;
-  }
-  
-  .reg-btn-time[disabled] {
-    background: #e0e0e0;
-    color: #b0b0b0;
-    cursor: not-allowed;
-    border: 1px solid #cccccc;
-    opacity: 0.7;
-  }
-  
-  .reg-form-actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
-    margin-top: 18px;
-  }
-  
-  .reg-btn-main {
-    background: #e6f0ff;
-    color: #2563eb;
-    border: none;
-    border-radius: 7px;
-    padding: 8px 22px;
-    font-size: 1rem;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  
-  .reg-btn-main:hover {
-    background: #82a5f0;
-  }
-  
-  .reg-btn-sub {
-    background: rgb(253, 179, 179);
-    color: red;
-    border: none;
-    border-radius: 7px;
-    padding: 8px 18px;
-    font-size: 1rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-  
-  .reg-btn-sub:hover {
-    background: rgb(255, 110, 110);
-  }
-  
-  .reg-helper-danger {
-    color: #e74c3c;
-    font-size: 0.95em;
-    margin-top: 4px;
-  }
+  max-width: 700px;
+  min-width: 500px;
+  margin: 40px auto;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 2px 8px rgba(30, 64, 175, 0.06);
+  padding: 32px 28px 24px 28px;
+  border: 1px solid #f0f1f3;
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+.reg-reservation-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #222;
+  margin-bottom: 24px;
+  letter-spacing: -0.5px;
+}
+
+.reg-reservation-form {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+
+.reg-form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.reg-form-label {
+  font-size: 1rem;
+  color: black;
+  font-weight: 400;
+  margin-bottom: 2px;
+  letter-spacing: -0.5px;
+}
+
+.reg-required {
+  color: #e74c3c;
+  margin-left: 2px;
+  font-size: 1em;
+}
+
+.reg-form-input {
+  border: 1.5px solid #e5e7eb;
+  border-radius: 7px;
+  padding: 9px 12px;
+  font-size: 1rem;
+  background: #f8fafc;
+  transition: border 0.2s;
+  outline: none;
+  resize: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.reg-form-input:focus {
+  border-color: #2563eb;
+  background: #fff;
+}
+
+.reg-dropdown-group {
+  position: relative;
+  width: 100%;
+}
+
+.reg-dropdown-btn {
+  width: 100%;
+  background: #f8fafc;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 7px;
+  padding: 9px 12px;
+  font-size: 1rem;
+  color: #222;
+  text-align: left;
+  cursor: pointer;
+  transition: border 0.2s;
+}
+
+.reg-dropdown-btn:focus, .reg-dropdown-btn[aria-expanded='true'] {
+  border-color: #2563eb;
+  background: #fff;
+}
+
+.reg-dropdown-menu {
+  position: absolute;
+  top: 110%;
+  left: 0;
+  width: 100%;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(30, 64, 175, 0.08);
+  z-index: 10;
+  padding: 4px 0;
+  margin: 0;
+  list-style: none;
+  display: none;
+}
+
+.reg-dropdown-btn[aria-expanded='true'] + .reg-dropdown-menu {
+  display: block;
+}
+
+.reg-dropdown-item {
+  padding: 8px 16px;
+  cursor: pointer;
+  color: black;
+  font-weight: 500;
+  transition: background 0.15s;
+  border-radius: 6px;
+}
+
+.reg-dropdown-item:hover {
+  background: #e3eafc;
+}
+
+.reg-time-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.reg-btn-time {
+  background: #f3f4f6;
+  color: black;
+  border: 1.5px solid #e5e7eb;
+  border-radius: 7px;
+  padding: 7px 18px;
+  font-size: 1.2rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, border 0.2s;
+}
+
+.reg-btn-time:hover {
+  background: #e3eafc;
+  border-color: #e6f0ff;
+}
+
+.reg-btn-time.active {
+  background: #2563eb;
+  color: #fff;
+  border-color: #2563eb;
+}
+
+.reg-btn-time[disabled] {
+  background: #e0e0e0;
+  color: #b0b0b0;
+  cursor: not-allowed;
+  border: 1px solid #cccccc;
+  opacity: 0.7;
+}
+
+.reg-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.reg-btn-main {
+  background: #e6f0ff;
+  color: #2563eb;
+  border: none;
+  border-radius: 7px;
+  padding: 8px 22px;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.reg-btn-main:hover {
+  background: #82a5f0;
+}
+
+.reg-btn-sub {
+  background: rgb(253, 179, 179);
+  color: red;
+  border: none;
+  border-radius: 7px;
+  padding: 8px 18px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.reg-btn-sub:hover {
+  background: rgb(255, 110, 110);
+}
+
+.reg-helper-danger {
+  color: #e74c3c;
+  font-size: 0.95em;
+  margin-top: 4px;
+}

--- a/frontend/src/assets/css/ReservationListByStaff.css
+++ b/frontend/src/assets/css/ReservationListByStaff.css
@@ -1,3 +1,23 @@
+.wr-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+}
+
+.wr-card {
+  background: #fff;
+  border-radius: 16px;
+  width: 230px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.07);
+  padding: 0;
+  overflow: visible;
+}
+
+.wr-card-body, .doctor-header {
+  padding: 5px 10px;
+}
+
 .nav-arrow {
     width: 20px;
     height: 20px;
@@ -37,87 +57,6 @@
     z-index: 9999 !important;
 }
 
-/* 카드 전체 리스트 */
-.card-list {
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  align-items: center;
-}
-
-/* 개별 카드 */
-.card {
-  background: #fff;
-  border-radius: 16px;
-  width: 230px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.07);
-  padding: 0;
-  overflow: hidden;
-}
-
-.card-body, .doctor-header {
-  padding: 5px 10px;
-}
-
-.card, .card-body {
-  overflow: visible !important;
-}
-
-/* 의사 헤더 */
-.doctor-header {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: #f8faff;
-  border-bottom: 1px solid #eee;
-}
-
-.doctor-name {
-  font-weight: 600;
-  font-size: 1.1rem;
-}
-.patient-count {
-  margin-left: auto;
-  color: #888;
-  font-size: 0.95rem;
-}
-
-/* 환자 리스트 */
-.patient-item {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 12px 0;
-  border-bottom: 1px solid #f0f0f0;
-}
-.patient-item:last-child {
-  border-bottom: none;
-}
-.patient-info {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  cursor: pointer;
-}
-.patient-name {
-  font-weight: 500;
-  font-size: 1rem;
-}
-.patient-meta {
-  color: #888;
-  font-size: 0.95rem;
-}
-.patient-type {
-  color: #666;
-  font-size: 0.95rem;
-}
-.patient-status {
-  min-width: 80px;
-  display: flex;
-  justify-content: flex-end;
-}
-
-/* 상태 버튼 */
 .status-btn {
   border: none;
   border-radius: 16px;
@@ -129,17 +68,21 @@
   color: #555;
   transition: background 0.2s, color 0.2s;
 }
+
 .status-inprogress {
   background: #f8faff !important;
   color: #2563eb !important;
 }
+
 .status-waiting {
   background: #fff7e6 !important;
   color: #f59e42 !important;
 }
+
 .status-btn.dropdown-toggle::after {
   margin-left: 8px;
 }
+
 .status-dropdown {
   min-width: 90px;
   font-size: 0.95rem;
@@ -148,19 +91,19 @@
   padding: 4px 0;
   z-index: 9999 !important;
 }
+
 .status-dropdown li {
   padding: 6px 18px;
   cursor: pointer;
 }
+
 .status-dropdown li:hover {
   background: #f6f8fa;
 }
 
-/* 대기 환자 없음 */
 .no-patient {
   color: #aaa;
   text-align: center;
   padding: 24px 0 16px 0;
   font-size: 1rem;
 }
-

--- a/frontend/src/assets/css/WaitingListDoctorName.css
+++ b/frontend/src/assets/css/WaitingListDoctorName.css
@@ -1,0 +1,12 @@
+.doctor-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: #f8faff;
+  border-bottom: 1px solid #eee;
+}
+
+.doctor-name {
+  font-weight: 600;
+  font-size: 1.1rem;
+}

--- a/frontend/src/assets/css/WaitingStatus.css
+++ b/frontend/src/assets/css/WaitingStatus.css
@@ -22,20 +22,28 @@
     border-color: #d1b3ff !important;
   }
 
-  .dropdown-menu {
-    min-width: 80px !important;
-    max-width: 180px !important;
-    width: max-content !important;
+  .ws-dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+  }
+
+  .ws-dropdown-menu {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    z-index: 1000;
+    min-width: 80px;
+    max-width: 180px;
+    width: max-content;
     box-sizing: border-box;
-    left: 0 !important;
-    right: 0 !important;
-    background: #fff;
+    background-color: #fff !important;
     border: 1px solid white;
     border-radius: 10px;
     margin-top: 4px;
+    padding: 0;
   }
   
-  .dropdown-menu li {
+  .ws-dropdown-menu li {
     cursor: pointer;
     color: black;
     font-weight: 500;
@@ -45,7 +53,7 @@
     list-style: none;
   }
   
-  .dropdown-menu li:hover {
+  .ws-dropdown-menu li:hover {
     background: rgb(236, 236, 236);
     color: black;
   }

--- a/frontend/src/assets/css/reservation.css
+++ b/frontend/src/assets/css/reservation.css
@@ -1,4 +1,4 @@
-.container {
+.reservation-list-by-patient {
     max-width: 800px;
     margin: 40px auto;
     padding: 24px;
@@ -16,56 +16,62 @@
     margin-bottom: 20px;
 }
 
-table {
+.reservationBox table {
     width: 100%;
     border-collapse: collapse;
     font-size: 15px;
     background-color: #fff;
 }
 
-thead {
+.reservationBox thead {
     background-color: #f1f5f9;
 }
 
-th, td {
+.reservationBox th, .reservationBox td {
     padding: 12px 16px;
     border-bottom: 1px solid #e0e0e0;
     text-align: center;
 }
 
-/* ✅ 세로 구분선 제거 */
-th:first-child,
-td:first-child {
+.reservationBox th:first-child,
+.reservationBox td:first-child {
     border-left: none;
 }
-th:last-child,
-td:last-child {
+.reservationBox th:last-child,
+.reservationBox td:last-child {
     border-right: none;
 }
-th, td {
+.reservationBox th, .reservationBox td {
     border-left: none;
     border-right: none;
 }
 
-th {
+.reservationBox th {
     font-weight: 600;
     color: #333;
 }
 
-td {
+.reservationBox td {
     color: #444;
 }
 
-/* 체크박스 */
-.form-check-input {
+.patient-reservation-check-input {
     width: 18px;
     height: 18px;
+    accent-color: #2563eb;
+    border: 2px solid #2563eb;
+    border-radius: 4px;
     cursor: pointer;
-    accent-color: #007bff;
+    vertical-align: middle;
+    margin-right: 6px;
+    transition: box-shadow 0.2s;
+  }
+  
+.patient-reservation-check-input:checked {
+box-shadow: 0 0 0 2px #a5d8ff;
 }
 
-/* 버튼 스타일 */
-.btn {
+.patient-reservation-btn-cancel {
     display: inline-block;
     padding: 10px 20px;
     font-size: 15px;
@@ -78,7 +84,7 @@ td {
     margin-top: 16px;
 }
 
-.btn:hover {
+.patient-reservation-btn-cancel:hover {
     background-color: #dc3545;
     color: white;
 }

--- a/frontend/src/assets/css/search.css
+++ b/frontend/src/assets/css/search.css
@@ -1,5 +1,5 @@
 
-.modal-backdrop {
+.search-modal-backdrop {
     position: fixed;
     top: 0;
     left: 0;
@@ -12,7 +12,7 @@
     z-index: 9999;
 }
 
-.modal-content {
+.search-modal-content {
     background-color: white;
     padding: 24px;
     border-radius: 16px;
@@ -23,12 +23,12 @@
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
 }
 
-.input-group {
+.search-input-group {
     display: flex;
     margin-bottom: 16px;
 }
 
-.input-group input {
+.search-input-group input {
     flex: 1;
     padding: 10px;
     font-size: 16px;
@@ -38,11 +38,11 @@
     transition: border 0.2s;
 }
 
-.input-group input:focus {
+.search-input-group input:focus {
     border-color: #e6f0ff;
 }
 
-.input-group button {
+.search-input-group button {
     padding: 6px 12px;
     background-color: #f1f1f1;
     border: 1px solid #ccc;
@@ -51,7 +51,7 @@
     transition: background-color 0.2s;
 }
 
-.input-group button:hover {
+.search-input-group button:hover {
     background-color: #e6f0ff;
 }
 
@@ -60,19 +60,15 @@
     height: 20px;
 }
 
-.menu-item:hover {
-    cursor: pointer
-}
-
 .search-title {
     font-size: 1.1rem;
     font-weight: 600;
     color: #222;
     margin-bottom: 24px;
     letter-spacing: -0.5px;
-  }
+}
 
-table {
+.search-results table {
     width: 100%;
     border-collapse: separate;
     border-spacing: 0;
@@ -83,27 +79,27 @@ table {
     box-shadow: 0 0 0 1px #ddd;
 }
 
-tr {
+.search-results tr {
     cursor: pointer;
 }
 
-th,
-td {
+.search-results th,
+.search-results td {
     padding: 10px;
     border-bottom: 1px solid #eee;
     text-align: center;
 }
 
-th {
+.search-results th {
     background-color: #e6f0ff;
     font-weight: 600;
 }
 
-tr:last-child td {
+.search-results tr:last-child td {
     border-bottom: none;
 }
 
-td button {
+.search-results td button {
     padding: 6px 12px;
     font-size: 14px;
     border-radius: 8px;
@@ -113,18 +109,18 @@ td button {
     transition: background-color 0.2s;
 }
 
-td button:hover {
+.search-results td button:hover {
     background-color: #e6f0ff;
 }
 
-.no-result {
+.search-no-result {
     margin-top: 16px;
     color: #666;
     text-align: center;
     font-style: italic;
 }
 
-.close-btn {
+.search-close-btn {
     margin-top: 20px;
     padding: 10px 16px;
     background-color: #f5f5f5;
@@ -134,6 +130,6 @@ td button:hover {
     transition: background-color 0.2s;
 }
 
-.close-btn:hover {
+.search-close-btn:hover {
     background-color: #e6f0ff;
 }

--- a/frontend/src/assets/css/waitingreservaion.css
+++ b/frontend/src/assets/css/waitingreservaion.css
@@ -1,4 +1,4 @@
-.d-flex .container {
+.wr-parent-container {
   width: 250px;
   padding: 0;
   margin: 5px 0;
@@ -44,7 +44,7 @@
 
 }
 
-.patient-item {
+/* .patient-item {
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -53,7 +53,7 @@
 .patient-name {
   display: inline-block;
   white-space: nowrap;
-}
+} */
 
 .patient-info {
   display: flex;
@@ -62,4 +62,33 @@
   gap: 8px;
   flex: none;
   min-width: 0;
+}
+
+.patient-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 0;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.patient-item:last-child {
+  border-bottom: none;
+}
+
+.patient-info {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  cursor: pointer;
+} 
+
+ .patient-name {
+  font-weight: 500;
+  font-size: 1rem;
+}
+
+.patient-meta {
+  color: #888;
+  font-size: 0.95rem;
 }

--- a/frontend/src/reception/components/WaitingList.vue
+++ b/frontend/src/reception/components/WaitingList.vue
@@ -51,14 +51,14 @@ import dayjs from "dayjs";
 </script>
 
 <template>
-  <div class="container">
+  <div class="reception-container">
     <div class="date-nav">
       <span class="date-display" @click="toggleCalendar">{{today.format("M월 D일")}}</span>
     </div>
-    <div class="card-list">
-      <div v-for="list in waitingList" :key="list.doctor?.uuid" class="card">
+    <div class="wr-card-list">
+      <div v-for="list in waitingList" :key="list.doctor?.uuid" class="wr-card">
         <WaitingListDoctorName :value="list.doctor" :count="list.patientList?.length || 0" />
-        <div class="card-body">
+        <div class="wr-card-body">
           <div v-if="!list.patientList || list.patientList.length < 1" class="no-patient">
             <span>대기 환자가 없습니다.</span>
           </div>

--- a/frontend/src/reservation/views/ReservationListByPatient.vue
+++ b/frontend/src/reservation/views/ReservationListByPatient.vue
@@ -53,7 +53,7 @@ import {common} from "@/util/common.js";
 
 <template>
 
-  <div class="container">
+  <div class="container reservation-list-by-patient">
     <div class="reservationBox">
       <table>
         <thead>
@@ -66,7 +66,7 @@ import {common} from "@/util/common.js";
         <tbody>
           <template v-if="reservationList.length > 0">
             <tr v-for="reservation in reservationList" :key="reservation.uuid">
-              <td><input class="form-check-input" type="checkbox" @change="checked" :value="reservation.uuid"></td>
+              <td><input class="patient-reservation-check-input" type="checkbox" @change="checked" :value="reservation.uuid"></td>
               <td>{{reservation.name}}</td>
               <td><span v-cloak>{{dayjs(reservation.reservationDate).format('MM월 DD일 HH시 mm분')}}</span></td>
             </tr>
@@ -79,7 +79,7 @@ import {common} from "@/util/common.js";
         </tbody>
       </table>
     </div>
-  <button type="button" class="btn btn-outline-danger" @click="cancelReservation">예약 취소</button>
+  <button type="button" class="patient-reservation-btn-cancel" @click="cancelReservation">예약 취소</button>
   </div>
 
 </template>

--- a/frontend/src/shared/components/WaitingListDoctorName.vue
+++ b/frontend/src/shared/components/WaitingListDoctorName.vue
@@ -1,4 +1,5 @@
 <script setup>
+import "@/assets/css/WaitingListDoctorName.css";
 
 defineProps({
   value: Object,

--- a/frontend/src/staff/components/WaitingReservationParent.vue
+++ b/frontend/src/staff/components/WaitingReservationParent.vue
@@ -27,7 +27,7 @@ const list = (selectedKey) => {
 
 <template>
 
-  <div class="d-flex container">
+  <div class="d-flex wr-parent-container">
     <div class="scroll">
       <div class="waitingAndReservation">
         <div

--- a/frontend/src/staff/views/ReservationListByStaff.vue
+++ b/frontend/src/staff/views/ReservationListByStaff.vue
@@ -138,12 +138,12 @@ onMounted(() => {
         prevent-min-max-navigation
       />
     </div>
-    <div class="card-list">
-      <div v-for="list in fullReservationList" :key="list.doctor?.uuid" class="card">
+    <div class="wr-card-list">
+      <div v-for="list in fullReservationList" :key="list.doctor?.uuid" class="wr-card">
         <WaitingListDoctorName :value="list.doctor" :count="list.patientList?.length || 0" />
-        <div class="card-body">
+        <div class="wr-card-body">
           <div v-if="!list.patientList || list.patientList.length < 1" class="no-patient">
-            <span>대기 환자가 없습니다.</span>
+            <span>예약 환자가 없습니다.</span>
           </div>
           <div v-else>
             <WaitingListPatientList

--- a/frontend/src/staff/views/Search.vue
+++ b/frontend/src/staff/views/Search.vue
@@ -1,12 +1,12 @@
 <template>
-  <div class="modal-backdrop" @click.self="emit('close')">
-    <div class="modal-content">
+  <div class="search-modal-backdrop" @click.self="emit('close')">
+    <div class="search-modal-content">
       <div class="search-title">
         <img src="@/assets/icons/search.png" alt="검색" class="icon"/>
         환자검색
       </div>
 
-      <div class="input-group">
+      <div class="search-input-group">
         <input
             type="text"
             v-model="searchVal.input"
@@ -20,7 +20,7 @@
         </button>
       </div>
 
-      <div class="results">
+      <div class="search-results">
         <table v-if="runSearch && searchRes.length > 0">
           <thead>
           <tr>
@@ -42,12 +42,12 @@
           </tbody>
         </table>
 
-        <div v-if="runSearch && searchRes.length < 1" class="no-result">
+        <div v-if="runSearch && searchRes.length < 1" class="search-no-result">
           검색결과가 존재하지 않습니다.
         </div>
       </div>
 
-      <button class="close-btn" @click="emit('close')">닫기</button>
+      <button class="search-close-btn" @click="emit('close')">닫기</button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# 작업 내용
## 부트스트랩 CSS 커스터마이징 삭제
- 기존 부트스트랩 CSS 커스터마이징했던 코드들 삭제.
- 별도의 새로운 클래스로 분리해 적용.
- 단, container 나 btn 같이 그대로 가져다쓰는 경우는 그대로 사용.