### PR TITLE
당일 대기 목록만 가져오도록 주석 해제

### DIFF
--- a/server/src/main/resources/mappers/reception/reception.xml
+++ b/server/src/main/resources/mappers/reception/reception.xml
@@ -31,9 +31,8 @@
             R.DOCTOR_UUID = #{doctorUuid}
             AND
             R.STATUS IN ('RE01', 'RE03')
---          오늘 날짜만 조회하기 위해 설정했지만 테스트위해 일단 생략
---           AND
---           R.CREATE_DATE BETWEEN CURDATE() AND CURDATE() + INTERVAL 1 DAY
+          AND
+          R.CREATE_DATE BETWEEN CURDATE() AND CURDATE() + INTERVAL 1 DAY
         ORDER BY
             TURN;
     </select>

--- a/server/src/main/resources/mappers/reservation/reservation.xml
+++ b/server/src/main/resources/mappers/reservation/reservation.xml
@@ -22,9 +22,9 @@
         VALUES
             (
                 UUID(),
-                #{patientUuid}, -- 임시 데이터
+                #{patientUuid},
                 #{doctorUuid},
-                'RS01', -- 임시 데이터
+                'RS01',
                 #{dateTime},
                 #{symptom}
             )


### PR DESCRIPTION
# 작업 내용
## 당일 대기 목록만 가져오도록 주석해제
- reception.xml
- 테스트용으로 이전 날짜 대기 목록도 가져왔으나, 
실제 연동 테스트 위해 당일 목록만 가져오도록 기존 주석처리 해제.

## 불필요한 주석 삭제
- reservation.xml 에 불필요한 주석 삭제 처리