### PR TITLE
공개 URL 처리 수정

### DIFF
--- a/server/src/main/java/com/emr/slgi/auth/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/emr/slgi/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.emr.slgi.auth.filter;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -9,8 +10,10 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import com.emr.slgi.config.SecurityConstants;
 import com.emr.slgi.member.enums.MemberRole;
 import com.emr.slgi.util.JwtUtil;
 
@@ -26,10 +29,19 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+    private final AntPathMatcher matcher = new AntPathMatcher();
+
     private final JwtUtil jwtUtil;
 
     @Value("${jwt.access-token-secret}")
     private String jwtSecret;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getServletPath();
+        return Arrays.stream(SecurityConstants.PUBLIC_URLS)
+            .anyMatch(pattern -> matcher.match(pattern, path));
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
+++ b/server/src/main/java/com/emr/slgi/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -26,31 +25,16 @@ import lombok.RequiredArgsConstructor;
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    private static final String[] PUBLIC_URLS = {
-        "/auth/**",
-        "/error",
-        "/api-docs",
-        "/swagger-ui/**",
-        "/v3/api-docs/**",
-        "/ws/**"
-    };
-
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
-    @Bean
-    WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring().requestMatchers(PUBLIC_URLS);
-    }
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
             .csrf((csrf) -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/image/**").permitAll() //지울예정
+                .requestMatchers(SecurityConstants.PUBLIC_URLS).permitAll()
                 .anyRequest().authenticated()
             )
-            
             .exceptionHandling(exceptionHandling -> exceptionHandling
                 .authenticationEntryPoint(unauthorizedEntryPoint())
                 .accessDeniedHandler(forbiddenHandler())

--- a/server/src/main/java/com/emr/slgi/config/SecurityConstants.java
+++ b/server/src/main/java/com/emr/slgi/config/SecurityConstants.java
@@ -1,0 +1,17 @@
+package com.emr.slgi.config;
+
+public class SecurityConstants {
+
+    private SecurityConstants() {}
+
+    public static final String[] PUBLIC_URLS = {
+        "/auth/**",
+        "/error",
+        "/api-docs",
+        "/swagger-ui/**",
+        "/v3/api-docs/**",
+        "/ws/**",
+        "/image/**"
+    };
+
+}


### PR DESCRIPTION
# 작업 내용
## WebSecurityCustomizer 제거
- WebSecurityCustomizer는 정적 리소스를 공개하는데 사용되는 클래스
- 기존의 shouldNotFilter()와 permitAll()로 대체
## PUBLIC_URLS 상수화
- shouldNotFilter()와 permitAll()에서 공통적으로 필요한 값들 상수화