### PR TITLE
배포 조건 변경

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,8 +1,11 @@
 name: SlgiEMR
-on: 
-  push: 
-    branches: [main] 
-
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  
 jobs:
     
   build:


### PR DESCRIPTION
# 작업 내용
## 배포 조건 변경
-  기존에는 main에 병합되면 자동 배포 수행.
- main에 병합과 함께, 릴리즈 버전태그 붙여야 Git Action 수행되도록 변경.
- 실제 릴리즈 버전만 배포.
- 운영 서버 기준.