### PR TITLE
배포 조건 변경 및 Redis Volume 설정 변경

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,8 +1,11 @@
 name: SlgiEMR
-on: 
-  push: 
-    branches: [main] 
-
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+  
 jobs:
     
   build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: ${REDIS_IMAGE}
     container_name: slgi-emr-redis
     volumes:
-      - ./redis/redis.conf:/etc/redis/redis.conf
+      - /home/ubuntu/redis/redis.conf:/etc/redis/redis.conf
     command: ["redis-server", "/etc/redis/redis.conf"]
     restart: always
 

--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,3 +1,0 @@
-FROM mariadb:11.4
-
-COPY ./sql /docker-entrypoint-initdb.d/

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,5 +1,0 @@
-FROM redis:7.2
-
-COPY redis.conf /etc/redis/redis.conf
-
-CMD ["redis-server", "/etc/redis/redis.conf"]


### PR DESCRIPTION
# 작업 내용
## 배포 조건 변경
-  기존에는 main에 병합되면 자동 배포 수행.
- main에 병합과 함께, 릴리즈 버전태그 붙여야 Git Action 수행되도록 변경.
- 실제 릴리즈 버전만 배포.
- 운영 서버 기준.

## Volume 설정
- Redis.conf 파일을 서버에 복사해 넣고, /home/ubuntu/redis 에 Volume 설정.

## 마리아 DB 와 Redis 도커 파일 삭제
- Volume 이용하므로 더이상 사용하지 않아 삭제.