### PR TITLE
Volume 경로 수정 및 배포 실행 조건 변경

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1,8 +1,6 @@
 name: SlgiEMR
 on:
   push:
-    branches:
-      - main
     tags:
       - 'v*.*.*'
   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       .env
     volumes:
       - ./mariadb/sql:/docker-entrypoint-initdb.d/
-      - ./mariadb/data:/var/lib/mysql
+      - mariadb-data:/var/lib/mysql
       - ./mariadb/procedure:/var/run/procedure
     restart: always
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,16 +13,16 @@ services:
     env_file:
       .env
     volumes:
-      - /home/ubuntu/sql:/docker-entrypoint-initdb.d/
-      - /home/ubuntu/mariadb/data:/var/lib/mysql
-      - /home/ubuntu/procedure:/var/run/procedure
+      - ./mariadb/sql:/docker-entrypoint-initdb.d/
+      - ./mariadb/data:/var/lib/mysql
+      - ./mariadb/procedure:/var/run/procedure
     restart: always
 
   redis:
     image: ${REDIS_IMAGE}
     container_name: slgi-emr-redis
     volumes:
-      - /home/ubuntu/redis/redis.conf:/etc/redis/redis.conf
+      - ./redis/redis.conf:/etc/redis/redis.conf
     command: ["redis-server", "/etc/redis/redis.conf"]
     restart: always
 


### PR DESCRIPTION
# 작업 내용
## Volume 실행 경로 수정
- 상대경로로 Volume 경로 수정.
- 기존에는 절대 경로.
- 개발 환경과 서버 환경을 상대경로를 사용해 일치시켜 자동 배포 구현.

## 실행 조건 변경
- 이전에 변경한 조건은 main 에 병합하거나 태그를 붙이거나 중 하나를 만족하면 Git Action 실행.
- 그래서 git 명령어로 태그를 붙여야 Git Action으로 배포하도록 변경.